### PR TITLE
[Fix] Record Page 관련 버그 수정

### DIFF
--- a/apps/web/src/features/record/lib/getChartData.ts
+++ b/apps/web/src/features/record/lib/getChartData.ts
@@ -1,4 +1,4 @@
-import { groupBy, pipe } from 'remeda'
+import { groupBy, mapValues, pipe } from 'remeda'
 
 import {
   type EmotionGroup,
@@ -17,19 +17,42 @@ export const getChartData = (emotionGroupList: EmotionGroup[]): ChartData[] => {
   const groupedData = pipe(
     emotionGroupList,
     groupBy((data) => formatTime(data.groupStart)),
+    mapValues((timeGroup) => {
+      const emotionTimeGroup = timeGroup.reduce(
+        (acc, item) => {
+          acc[item.emotionType] = {
+            ...acc[item.emotionType],
+            count: acc[item.emotionType].count + item.count,
+          }
+          return acc
+        },
+        {
+          POSITIVE: {
+            groupStart: '',
+            emotionType: 'POSITIVE',
+            count: 0,
+          },
+          NEGATIVE: {
+            groupStart: '',
+            emotionType: 'NEGATIVE',
+            count: 0,
+          },
+        } as Record<EmotionType, EmotionGroup>,
+      )
+
+      return emotionTimeGroup
+    }),
   )
 
   // 시간대별로 emotion Type 선정
   const parseData = Object.entries(groupedData).map((item) => {
-    const positiveData = item[1].find((data) => data.emotionType === 'POSITIVE')
-    const negativeData = item[1].find((data) => data.emotionType === 'NEGATIVE')
+    const positiveCount = item[1].POSITIVE.count
+    const negativeCount = item[1].NEGATIVE.count
 
-    const positiveCount = positiveData?.count ?? 0
-    const negativeCount = negativeData?.count ?? 0
     const totalCount = positiveCount + negativeCount
 
     // positive 수가 negative 초과 시
-    if (positiveCount > negativeCount) {
+    if (positiveCount >= negativeCount) {
       return {
         time: item[0],
         percent: parseFloat(((positiveCount / totalCount) * 100).toFixed(0)),

--- a/apps/web/src/features/record/ui/EmotionTimeLine.tsx
+++ b/apps/web/src/features/record/ui/EmotionTimeLine.tsx
@@ -5,11 +5,13 @@ import { EmotionLinearChart } from '@/entities/record/ui/EmotionLinearChart'
 import { getChartData } from '@/features/record/lib/getChartData'
 
 export const EmotionTimeLine = ({
-  emotionGroupList,
   positiveEmotionPercent,
+  negativeEmotionPercent,
+  emotionGroupList,
 }: {
-  emotionGroupList: EmotionGroup[]
   positiveEmotionPercent: number
+  negativeEmotionPercent: number
+  emotionGroupList: EmotionGroup[]
 }) => {
   const chartData = getChartData(emotionGroupList)
 
@@ -17,7 +19,10 @@ export const EmotionTimeLine = ({
     <div className="w-full mt-10 flex flex-col gap-4">
       <SectionHeader title="감정 타임라인" className="px-4" />
       <div className="flex justify-center px-4">
-        <ProgressBar emotion="joy" emotionPercent={positiveEmotionPercent} />
+        <ProgressBar
+          positiveEmotionPercent={positiveEmotionPercent}
+          negativeEmotionPercent={negativeEmotionPercent}
+        />
       </div>
       <div className="inline-block overflow-x-auto ">
         <EmotionLinearChart ChartData={chartData} />

--- a/apps/web/src/mocks/data/record.ts
+++ b/apps/web/src/mocks/data/record.ts
@@ -69,49 +69,134 @@ const emotionGroupListShort: EmotionGroup[] = [
 
 export const emotionGroupList: EmotionGroup[] = [
   {
-    groupStart: '2025-08-15T14:03:00',
+    groupStart: '2025-07-28T19:04:00',
     emotionType: 'POSITIVE',
     count: 4,
   },
   {
-    groupStart: '2025-08-15T14:03:00',
+    groupStart: '2025-07-28T19:04:00',
     emotionType: 'NEGATIVE',
-    count: 9,
+    count: 4,
   },
   {
-    groupStart: '2025-08-15T14:03:00',
+    groupStart: '2025-07-28T19:05:01',
     emotionType: 'POSITIVE',
-    count: 5,
+    count: 4,
   },
   {
-    groupStart: '2025-08-15T14:03:00',
+    groupStart: '2025-07-28T19:05:01',
     emotionType: 'NEGATIVE',
-    count: 11,
+    count: 4,
   },
   {
-    groupStart: '2025-08-15T14:03:00',
+    groupStart: '2025-07-28T19:06:02',
+    emotionType: 'POSITIVE',
+    count: 54,
+  },
+  {
+    groupStart: '2025-07-28T19:06:02',
+    emotionType: 'NEGATIVE',
+    count: 14,
+  },
+  {
+    groupStart: '2025-07-28T19:07:03',
+    emotionType: 'POSITIVE',
+    count: 24,
+  },
+  {
+    groupStart: '2025-07-28T19:07:03',
+    emotionType: 'NEGATIVE',
+    count: 14,
+  },
+  {
+    groupStart: '2025-07-28T19:08:04',
+    emotionType: 'POSITIVE',
+    count: 54,
+  },
+  {
+    groupStart: '2025-07-28T19:08:04',
+    emotionType: 'NEGATIVE',
+    count: 34,
+  },
+  {
+    groupStart: '2025-07-28T19:09:05',
+    emotionType: 'POSITIVE',
+    count: 8,
+  },
+  {
+    groupStart: '2025-07-28T19:09:05',
+    emotionType: 'NEGATIVE',
+    count: 6,
+  },
+  {
+    groupStart: '2025-07-28T19:10:06',
+    emotionType: 'POSITIVE',
+    count: 2,
+  },
+  {
+    groupStart: '2025-07-28T19:10:06',
+    emotionType: 'NEGATIVE',
+    count: 4,
+  },
+  {
+    groupStart: '2025-07-28T19:11:06',
+    emotionType: 'POSITIVE',
+    count: 2,
+  },
+  {
+    groupStart: '2025-07-28T19:11:06',
+    emotionType: 'NEGATIVE',
+    count: 4,
+  },
+  {
+    groupStart: '2025-07-28T19:12:06',
+    emotionType: 'POSITIVE',
+    count: 2,
+  },
+  {
+    groupStart: '2025-07-28T19:12:06',
+    emotionType: 'NEGATIVE',
+    count: 4,
+  },
+  {
+    groupStart: '2025-07-28T19:13:06',
+    emotionType: 'POSITIVE',
+    count: 2,
+  },
+  {
+    groupStart: '2025-07-28T19:13:06',
+    emotionType: 'NEGATIVE',
+    count: 14,
+  },
+  {
+    groupStart: '2025-07-28T19:14:06',
+    emotionType: 'POSITIVE',
+    count: 2,
+  },
+  {
+    groupStart: '2025-07-28T19:14:06',
+    emotionType: 'NEGATIVE',
+    count: 41,
+  },
+  {
+    groupStart: '2025-07-28T19:15:06',
+    emotionType: 'POSITIVE',
+    count: 21,
+  },
+  {
+    groupStart: '2025-07-28T19:15:06',
+    emotionType: 'NEGATIVE',
+    count: 4,
+  },
+  {
+    groupStart: '2025-07-28T19:16:06',
     emotionType: 'POSITIVE',
     count: 22,
   },
   {
-    groupStart: '2025-08-15T14:03:00',
+    groupStart: '2025-07-28T19:16:06',
     emotionType: 'NEGATIVE',
     count: 4,
-  },
-  {
-    groupStart: '2025-08-15T14:03:00',
-    emotionType: 'POSITIVE',
-    count: 7,
-  },
-  {
-    groupStart: '2025-08-15T14:03:00',
-    emotionType: 'NEGATIVE',
-    count: 3,
-  },
-  {
-    groupStart: '2025-08-15T14:03:00',
-    emotionType: 'POSITIVE',
-    count: 51,
   },
 ]
 

--- a/apps/web/src/pages/record/ui/RecordDetailPage.tsx
+++ b/apps/web/src/pages/record/ui/RecordDetailPage.tsx
@@ -58,9 +58,8 @@ export const RecordDetailPage = ({
 
           <ImageTimeLine matchRecordId={data?.data.matchRecordId ?? 0} />
           <EmotionTimeLine
-            positiveEmotionPercent={Math.round(
-              data?.data?.positiveEmotionPercent ?? 0,
-            )}
+            positiveEmotionPercent={data?.data.positiveEmotionPercent ?? 0}
+            negativeEmotionPercent={data?.data.negativeEmotionPercent ?? 0}
             emotionGroupList={data?.data.emotionGroupList ?? []}
           />
           <BottomButtonGroup recordId={data?.data.matchRecordId ?? 0} />

--- a/apps/web/src/pages/record/ui/RecordMainPage.tsx
+++ b/apps/web/src/pages/record/ui/RecordMainPage.tsx
@@ -17,13 +17,19 @@ const RecordMainContent = ({
 }: {
   data: RecordResponseDTO | undefined
 }) => {
-  const { totalCount, winRate, totalNegativeEmotionPercent, records } =
-    data?.data ?? {
-      totalCount: 0,
-      winRate: 0,
-      totalNegativeEmotionPercent: 0,
-      records: [],
-    }
+  const {
+    totalCount,
+    winRate,
+    totalNegativeEmotionPercent,
+    totalPositiveEmotionPercent,
+    records,
+  } = data?.data ?? {
+    totalCount: 0,
+    winRate: 0,
+    totalNegativeEmotionPercent: 0,
+    totalPositiveEmotionPercent: 0,
+    records: [],
+  }
 
   return (
     <>
@@ -50,7 +56,7 @@ const RecordMainContent = ({
                 },
                 {
                   name: '기뻐요',
-                  value: parseInt(totalNegativeEmotionPercent.toString()),
+                  value: parseInt(totalPositiveEmotionPercent.toString()),
                 },
               ]}
             />

--- a/apps/web/src/pages/record/ui/RecordMainPage.tsx
+++ b/apps/web/src/pages/record/ui/RecordMainPage.tsx
@@ -43,8 +43,16 @@ const RecordMainContent = ({
             <EmotionCard.Disabled />
           ) : (
             <EmotionCard.Active
-              emotion={'화나요'}
-              rate={parseInt(totalNegativeEmotionPercent.toString())}
+              data={[
+                {
+                  name: '화나요',
+                  value: parseInt(totalNegativeEmotionPercent.toString()),
+                },
+                {
+                  name: '기뻐요',
+                  value: parseInt(totalNegativeEmotionPercent.toString()),
+                },
+              ]}
             />
           )}
         </div>

--- a/apps/web/src/shared/ui/common/Card/EmotionCard.tsx
+++ b/apps/web/src/shared/ui/common/Card/EmotionCard.tsx
@@ -37,11 +37,11 @@ interface DisabledEmotionCardProps extends ComponentProps<'div'> {}
 const Active = ({ data, className, ...rest }: ActiveEmotionCardProps) => {
   const chartData = data
 
-  const madValue = chartData.find((d) => d.name === '화나요')!.value
-  const happyValue = chartData.find((d) => d.name === '기뻐요')!.value
+  const angryValue = chartData.find((d) => d.name === '화나요')!.value
+  const joyValue = chartData.find((d) => d.name === '기뻐요')!.value
 
-  const centerEmotion = madValue >= happyValue ? '화나요' : '기뻐요'
-  const centerRate = centerEmotion === '화나요' ? madValue : happyValue
+  const centerEmotion = angryValue >= joyValue ? '화나요' : '기뻐요'
+  const centerRate = centerEmotion === '화나요' ? angryValue : joyValue
 
   const progressColor =
     centerEmotion === '화나요'
@@ -49,8 +49,8 @@ const Active = ({ data, className, ...rest }: ActiveEmotionCardProps) => {
       : 'var(--color-brand-green-hover)'
   const trackColor = 'var(--color-usage-background-strong)'
 
-  const startAngle = madValue <= 50 ? 90 : 0
-  const endAngle = madValue <= 50 ? 450 : 360
+  const startAngle = angryValue <= 50 ? 90 : 0
+  const endAngle = angryValue <= 50 ? 450 : 360
 
   const dominantOnly = [
     { name: 'progress', value: centerRate, fill: progressColor },

--- a/apps/web/src/shared/ui/common/Card/EmotionCard.tsx
+++ b/apps/web/src/shared/ui/common/Card/EmotionCard.tsx
@@ -5,9 +5,13 @@ import AngryEmotion from '@/assets/angryEmotion.svg?react'
 import JoyEmotion from '@/assets/joyEmotion.svg?react'
 import { cn } from '@/shared/lib/classnames'
 
+interface EmotionPieChartData {
+  name: '화나요' | '기뻐요'
+  value: number
+}
+
 interface ActiveEmotionCardProps extends ComponentProps<'div'> {
-  emotion: '화나요' | '기뻐요'
-  rate: number
+  data: EmotionPieChartData[]
 }
 
 interface DisabledEmotionCardProps extends ComponentProps<'div'> {}
@@ -30,30 +34,14 @@ interface DisabledEmotionCardProps extends ComponentProps<'div'> {}
  * <EmotionCard.Disabled />
  * ```
  */
-const Active = ({
-  emotion,
-  rate,
-  className,
-  ...rest
-}: ActiveEmotionCardProps) => {
-  const chartData = [
-    {
-      name: '화나요',
-      value: emotion === '화나요' ? rate : 100 - rate,
-      fill: 'var(--color-brand-red-hover)',
-    },
-    {
-      name: '기뻐요',
-      value: emotion === '기뻐요' ? rate : 100 - rate,
-      fill: 'var(--color-brand-green-hover)',
-    },
-  ]
+const Active = ({ data, className, ...rest }: ActiveEmotionCardProps) => {
+  const chartData = data
 
   const madValue = chartData.find((d) => d.name === '화나요')!.value
   const happyValue = chartData.find((d) => d.name === '기뻐요')!.value
-  
-  const centerEmotion = madValue >= happyValue ? '화나요' : '기뻐요'
-  const centerRate = centerEmotion === '화나요' ? madValue : happyValue
+
+  const centerEmotion = madValue <= happyValue ? '기뻐요' : '화나요'
+  const centerRate = centerEmotion === '기뻐요' ? happyValue : madValue
 
   const startAngle = madValue <= 50 ? 90 : 0
   const endAngle = madValue <= 50 ? 450 : 360

--- a/apps/web/src/shared/ui/common/ProgressBar/ProgressBar.tsx
+++ b/apps/web/src/shared/ui/common/ProgressBar/ProgressBar.tsx
@@ -5,38 +5,69 @@ import JoyEmotion from '@/assets/joyEmotion.svg?react'
 import AngryEmotion from '@/assets/angryEmotion.svg?react'
 
 interface RecordLogProgressProps extends ComponentProps<'div'> {
-  emotion: 'joy' | 'angry'
-  emotionPercent: number
+  positiveEmotionPercent: number
+  negativeEmotionPercent: number
 }
 
 /**
  * ProgressBar - 감정 비율을 시각적으로 표현하는 프로그레스 바 컴포넌트
  *
- * joy, angry 중 하나의 감정이 dominant한 상태를 전달받아
  * 좌우 양끝에 감정 아이콘과 퍼센트를 표시하고,
  * 가운데 바는 해당 감정 비율만큼 채워지는 형태로 렌더링됩니다.
  *
- * - 퍼센트 값은 emotionPercent로 전달되며, 나머지 감정은 100 - percent로 계산됩니다.
- * - 바 색상 및 방향은 감정 종류(emotion)에 따라 동적으로 변경됩니다.
+ * - 퍼센트 값은 positiveEmotionPercent, negativeEmotionPercent로 전달됩니다.
+ * - 바 색상 및 방향은 positiveEmotionPercent, negativeEmotionPercent에 따라 동적으로 변경됩니다.
  *
  * @props
- * @param {'joy' | 'angry'} emotion - 주 감정 (bar 색상, 방향 결정)
- * @param {number} emotionPercent - 해당 감정의 퍼센트 (0~100)
+ * @param {number} positiveEmotionPercent - 긍정 감정의 퍼센트 (0~100)
+ * @param {number} negativeEmotionPercent - 부정 감정의 퍼센트 (0~100)
  *
  * @example
- * <ProgressBar emotion="joy" emotionPercent={75} />
+ * <ProgressBar positiveEmotionPercent={75} negativeEmotionPercent={25} />
  */
 
-export const ProgressBar = ({
+const getBarColor = (
+  positiveEmotionPercent: number,
+  negativeEmotionPercent: number,
+) => {
+  if (positiveEmotionPercent >= negativeEmotionPercent) {
+    return ['bg-brand-green-default', 'bg-brand-red-default']
+  }
+  return ['bg-brand-red-default', 'bg-brand-green-default']
+}
+
+const EmotionIconWithPercent = ({
   emotion,
-  emotionPercent,
+  percent,
+}: {
+  emotion: 'joy' | 'angry'
+  percent: number
+}) => {
+  return (
+    <div className="flex flex-col items-center">
+      {emotion === 'joy' ? (
+        <JoyEmotion className="w-8 h-8" />
+      ) : (
+        <AngryEmotion className="w-8 h-8" />
+      )}
+      <span className="body-sm-bold text-usage-text-default text-center">
+        {percent}%
+      </span>
+    </div>
+  )
+}
+
+export const ProgressBar = ({
+  positiveEmotionPercent,
+  negativeEmotionPercent,
   className,
   ...rest
 }: RecordLogProgressProps) => {
-  const reversePercent = 100 - emotionPercent
-  const barColor =
-    emotion === 'joy' ? 'bg-brand-green-default' : 'bg-brand-red-default'
-  const progressStyle = { width: `${emotionPercent}%` }
+  const [barColor, backgroundColor] = getBarColor(
+    positiveEmotionPercent,
+    negativeEmotionPercent,
+  )
+  const progressStyle = { width: `${positiveEmotionPercent}%` }
 
   return (
     <div
@@ -50,27 +81,37 @@ export const ProgressBar = ({
       <div
         className={cn('flex flex-col', 'body-sm-bold text-usage-text-default')}
       >
-        <JoyEmotion className="w-8 h-8" />
-        <span>{emotion === 'joy' ? emotionPercent : reversePercent}%</span>
+        <EmotionIconWithPercent
+          emotion="joy"
+          percent={positiveEmotionPercent}
+        />
       </div>
-      <div className="relative w-full h-4 bg-usage-background-strong rounded-full overflow-hidden">
+      <div
+        className={cn(
+          'relative w-full h-4 rounded-full overflow-hidden',
+          backgroundColor,
+        )}
+      >
         <div
           className={cn(
             'absolute top-0 h-full',
             'transition-all duration-1000', // 멋진 효과
             barColor,
-            emotion === 'joy' ? 'left-0' : 'right-0',
+            positiveEmotionPercent >= negativeEmotionPercent
+              ? 'left-0'
+              : 'right-0',
           )}
           style={progressStyle}
         />
-        
       </div>
 
       <div
         className={cn('flex flex-col', 'body-sm-bold text-usage-text-default')}
       >
-        <AngryEmotion className="w-8 h-8" />
-        <span>{emotion === 'angry' ? emotionPercent : reversePercent}%</span>
+        <EmotionIconWithPercent
+          emotion="angry"
+          percent={negativeEmotionPercent}
+        />
       </div>
     </div>
   )

--- a/apps/web/src/stories/Card/EmotionCard.stories.tsx
+++ b/apps/web/src/stories/Card/EmotionCard.stories.tsx
@@ -7,16 +7,14 @@ const meta: Meta<typeof EmotionCard.Active> = {
   component: EmotionCard.Active,
   tags: ['autodocs'],
   args: {
-    emotion: '화나요',
-    rate: 50,
+    data: [
+      { name: '화나요', value: 50 },
+      { name: '기뻐요', value: 50 },
+    ],
   },
   argTypes: {
-    emotion: {
-      control: { type: 'radio' },
-      options: ['화나요', '기뻐요'],
-    },
-    rate: {
-      control: { type: 'range', min: 0, max: 100, step: 1 },
+    data: {
+      control: { type: 'object' },
     },
   },
 }
@@ -27,16 +25,22 @@ type Story = StoryObj<typeof EmotionCard.Active>
 export const Test: Story = {
   name: 'test',
   args: {
-    emotion: '화나요',
-    rate: 75,
+    data: [
+      { name: '화나요', value: 50 },
+      { name: '기뻐요', value: 50 },
+    ],
   },
 }
-
 
 export const Active_Mad: Story = {
   render: () => (
     <div style={{ height: '200px' }}>
-      <EmotionCard.Active emotion="화나요" rate={75} />
+      <EmotionCard.Active
+        data={[
+          { name: '화나요', value: 50 },
+          { name: '기뻐요', value: 50 },
+        ]}
+      />
     </div>
   ),
   name: 'Active - 화나요',
@@ -45,7 +49,12 @@ export const Active_Mad: Story = {
 export const Active_Happy: Story = {
   render: () => (
     <div style={{ height: '200px' }}>
-      <EmotionCard.Active emotion="기뻐요" rate={60} />
+      <EmotionCard.Active
+        data={[
+          { name: '화나요', value: 50 },
+          { name: '기뻐요', value: 50 },
+        ]}
+      />
     </div>
   ),
   name: 'Active - 기뻐요',

--- a/apps/web/src/stories/ProgressBar/ProgressBar.stories.tsx
+++ b/apps/web/src/stories/ProgressBar/ProgressBar.stories.tsx
@@ -7,11 +7,10 @@ const meta: Meta<typeof ProgressBar> = {
   component: ProgressBar,
   tags: ['autodocs'],
   argTypes: {
-    emotion: {
-      control: { type: 'radio' },
-      options: ['joy', 'angry'],
+    positiveEmotionPercent: {
+      control: { type: 'range', min: 0, max: 100, step: 1 },
     },
-    emotionPercent: {
+    negativeEmotionPercent: {
       control: { type: 'range', min: 0, max: 100, step: 1 },
     },
   },
@@ -22,8 +21,8 @@ type Story = StoryObj<typeof ProgressBar>
 
 export const JoyDominant: Story = {
   args: {
-    emotion: 'joy',
-    emotionPercent: 80,
+    positiveEmotionPercent: 80,
+    negativeEmotionPercent: 20,
   },
   decorators: [
     (Story) => (
@@ -36,8 +35,8 @@ export const JoyDominant: Story = {
 
 export const AngryDominant: Story = {
   args: {
-    emotion: 'angry',
-    emotionPercent: 75,
+    positiveEmotionPercent: 75,
+    negativeEmotionPercent: 25,
   },
   decorators: [
     (Story) => (


### PR DESCRIPTION
## Summary
- emotionTimeLine data 그룹 로직 수정
- emotion 데이터 0일 경우 버그 수정

## Detail
- emotionTimeLine emotion type에 따라 적절히 수정
  - 시간대별로 여러개가 올 수 있어서 emotionType 별로 묶는 로직 추가
- totalPositiveEmotionPercent 둘 다 0일 경우 처리
- progressBar 배경색 처리

<img width="366" height="785" alt="image" src="https://github.com/user-attachments/assets/a6a12a2e-fc41-4525-a0dc-a2b527b24cfe" />

<img width="357" height="783" alt="image" src="https://github.com/user-attachments/assets/04166408-214a-4b29-9478-d8d8926dd068" />

