### PR TITLE
빌드에러 수정

### DIFF
--- a/apps/web/src/features/home/ui/CharacterSection.tsx
+++ b/apps/web/src/features/home/ui/CharacterSection.tsx
@@ -16,7 +16,7 @@ export const CharacterSection = ({ emotion }: CharacterSectionProps) => {
   const { Character, label, emoji, badgeClass } = config
 
   const baseballTeam = user?.baseballTeam
-  const teamName = baseballTeam ? TEAMS[baseballTeam] : null
+  const teamName = baseballTeam ? TEAMS[baseballTeam] : TEAMS['NONE']
 
   return (
     <div className="flex flex-col items-center w-full pt-4">

--- a/apps/web/src/mocks/data/match.ts
+++ b/apps/web/src/mocks/data/match.ts
@@ -1,11 +1,13 @@
 import { type Match } from '@/entities/match/model/match.type'
 
+const today = new Date().toISOString().slice(0, 10)
+
 export const match = {
   today: {
     data: [
       {
         matchesId: 1,
-        matchesDate: '2026-03-19',
+        matchesDate: today,
         matchesTime: '18:30:00',
         homeTeam: 'LOTTE_GIANTS',
         awayTeam: 'KT_WIZ',
@@ -14,7 +16,7 @@ export const match = {
       },
       {
         matchesId: 2,
-        matchesDate: '2026-03-19',
+        matchesDate: today,
         matchesTime: '18:30:00',
         homeTeam: 'LG_TWINS',
         awayTeam: 'SSG_LANDERS',
@@ -23,7 +25,7 @@ export const match = {
       },
       {
         matchesId: 3,
-        matchesDate: '2026-03-19',
+        matchesDate: today,
         matchesTime: '19:30:00',
         homeTeam: 'LG_TWINS',
         awayTeam: 'SSG_LANDERS',
@@ -32,7 +34,7 @@ export const match = {
       },
       {
         matchesId: 4,
-        matchesDate: '2026-03-19',
+        matchesDate: today,
         matchesTime: '18:30:00',
         homeTeam: 'DOOSAN_BEARS',
         awayTeam: 'SSG_LANDERS',
@@ -41,7 +43,7 @@ export const match = {
       },
       {
         matchesId: 5,
-        matchesDate: '2026-03-19',
+        matchesDate: today,
         matchesTime: '19:30:00',
         homeTeam: 'LG_TWINS',
         awayTeam: 'SSG_LANDERS',
@@ -50,7 +52,7 @@ export const match = {
       },
       {
         matchesId: 6,
-        matchesDate: '2026-03-19',
+        matchesDate: today,
         matchesTime: '18:30:00',
         homeTeam: 'DOOSAN_BEARS',
         awayTeam: 'SSG_LANDERS',

--- a/apps/web/src/mocks/data/match.ts
+++ b/apps/web/src/mocks/data/match.ts
@@ -5,7 +5,7 @@ export const match = {
     data: [
       {
         matchesId: 1,
-        matchesDate: '2025-09-23',
+        matchesDate: '2026-03-19',
         matchesTime: '18:30:00',
         homeTeam: 'LOTTE_GIANTS',
         awayTeam: 'KT_WIZ',
@@ -14,7 +14,7 @@ export const match = {
       },
       {
         matchesId: 2,
-        matchesDate: '2025-09-23',
+        matchesDate: '2026-03-19',
         matchesTime: '18:30:00',
         homeTeam: 'LG_TWINS',
         awayTeam: 'SSG_LANDERS',
@@ -23,7 +23,7 @@ export const match = {
       },
       {
         matchesId: 3,
-        matchesDate: '2025-09-23',
+        matchesDate: '2026-03-19',
         matchesTime: '19:30:00',
         homeTeam: 'LG_TWINS',
         awayTeam: 'SSG_LANDERS',
@@ -32,7 +32,7 @@ export const match = {
       },
       {
         matchesId: 4,
-        matchesDate: '2025-09-23',
+        matchesDate: '2026-03-19',
         matchesTime: '18:30:00',
         homeTeam: 'DOOSAN_BEARS',
         awayTeam: 'SSG_LANDERS',
@@ -41,7 +41,7 @@ export const match = {
       },
       {
         matchesId: 5,
-        matchesDate: '2025-09-23',
+        matchesDate: '2026-03-19',
         matchesTime: '19:30:00',
         homeTeam: 'LG_TWINS',
         awayTeam: 'SSG_LANDERS',
@@ -50,7 +50,7 @@ export const match = {
       },
       {
         matchesId: 6,
-        matchesDate: '2025-09-23',
+        matchesDate: '2026-03-19',
         matchesTime: '18:30:00',
         homeTeam: 'DOOSAN_BEARS',
         awayTeam: 'SSG_LANDERS',

--- a/apps/web/src/mocks/data/recording.ts
+++ b/apps/web/src/mocks/data/recording.ts
@@ -1,5 +1,7 @@
 import type { RecordingResponse } from '@/entities/record/model/recording.type'
 
+const today = new Date().toISOString().slice(0, 10)
+
 export const recording: Record<number, RecordingResponse> = {
   // today match (matchesId: 2, LG_TWINS vs SSG_LANDERS) — recording exists, no emotions yet
   2: {
@@ -8,7 +10,7 @@ export const recording: Record<number, RecordingResponse> = {
     stadium: 'JAMSIL',
     homeTeam: 'LG_TWINS',
     awayTeam: 'SSG_LANDERS',
-    matchDate: '2026-03-19',
+    matchDate: today,
     matchTime: { hour: 18, minute: 30, second: 0, nano: 0 },
     userId: 4,
     watchCnt: 1,

--- a/apps/web/src/mocks/data/recording.ts
+++ b/apps/web/src/mocks/data/recording.ts
@@ -1,6 +1,26 @@
 import type { RecordingResponse } from '@/entities/record/model/recording.type'
 
 export const recording: Record<number, RecordingResponse> = {
+  // today match (matchesId: 2, LG_TWINS vs SSG_LANDERS) — recording exists, no emotions yet
+  2: {
+    matchRecordId: 2,
+    matchesId: 2,
+    stadium: 'JAMSIL',
+    homeTeam: 'LG_TWINS',
+    awayTeam: 'SSG_LANDERS',
+    matchDate: '2026-03-19',
+    matchTime: { hour: 18, minute: 30, second: 0, nano: 0 },
+    userId: 4,
+    watchCnt: 1,
+    result: null,
+    baseballTeam: 'LG_TWINS',
+    positiveEmotionPercent: 0,
+    negativeEmotionPercent: 0,
+    defaultImageUrl: '',
+    imageList: [],
+    emotionGroupList: [],
+  },
+
   101: {
     matchRecordId: 101,
     matchesId: 101,

--- a/apps/web/src/pages/home/ui/HomePage.tsx
+++ b/apps/web/src/pages/home/ui/HomePage.tsx
@@ -1,10 +1,10 @@
 import { AppScreen } from '@stackflow/plugin-basic-ui'
 import { type ActivityComponentType, useActivity } from '@stackflow/react'
-import { useFlow } from '@/app/routes/stackflow'
 import { useQuery } from '@tanstack/react-query'
 import { format, toZonedTime } from 'date-fns-tz'
 import { isBefore, isAfter, isToday } from 'date-fns'
 
+import { useFlow } from '@/app/routes/stackflow'
 import { matches } from '@/entities/match/api'
 import { MatchSection } from '@/features/match/ui/MatchSection'
 import { MatchEmptySection } from '@/features/match/ui/MatchEmptySection'
@@ -68,7 +68,7 @@ const HomePage: ActivityComponentType = () => {
     <AppScreen
       appBar={{
         title: <BallogAppBar />,
-        onPressBack: () => pop({ animate: false }),
+        backButton: { onClick: () => pop({ animate: false }) },
       }}
     >
       <DateProvider>

--- a/apps/web/src/pages/home/ui/HomePageV2.tsx
+++ b/apps/web/src/pages/home/ui/HomePageV2.tsx
@@ -1,6 +1,7 @@
 import { AppScreen } from '@stackflow/plugin-basic-ui'
 import { type ActivityComponentType } from '@stackflow/react'
 import { useQuery } from '@tanstack/react-query'
+import type { CSSProperties } from 'react'
 
 import { matches } from '@/entities/match/api'
 import type { EmotionType } from '@/entities/record/model/record.type'
@@ -94,7 +95,7 @@ const HomeContentV2 = ({
               {
                 '--calendar-frame-color': '#757575',
                 '--calendar-inside-color': '#ffffff',
-              } as React.CSSProperties
+              } as CSSProperties
             }
           />
           <span className="body-sm-medium text-usage-text-subtle">
@@ -126,7 +127,9 @@ const HomePageV2: ActivityComponentType = () => {
         />
         <div className="flex-1 overflow-y-auto">
           <HomeContentV2
-            onViewAllMatches={() => push('MatchSchedule', {}, { animate: false })}
+            onViewAllMatches={() =>
+              push('MatchSchedule', {}, { animate: false })
+            }
           />
         </div>
         <GlobalNavigationBar />

--- a/apps/web/src/pages/record/ui/RecordMainPage.tsx
+++ b/apps/web/src/pages/record/ui/RecordMainPage.tsx
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
 import { AppScreen } from '@stackflow/plugin-basic-ui'
 import { toast } from 'sonner'
-import { useFlow } from '@/app/routes/stackflow'
 
+import { useFlow } from '@/app/routes/stackflow'
 import { IntuitionCard } from '@/shared/ui/common/Card/intuitionCard'
 import { RecordList } from '@/features/record/ui/RecordList'
 import { EmotionCard } from '@/shared/ui/common/Card/EmotionCard'
@@ -88,7 +88,7 @@ export const RecordMainPage = () => {
         title: (
           <span className="text-usage-text-default body-md-bold">관람로그</span>
         ),
-        onPressBack: () => pop({ animate: false }),
+        backButton: { onClick: () => pop({ animate: false }) },
       }}
     >
       <AppLayout>


### PR DESCRIPTION
# [style] 홈 v2 UI 스타일 개선 및 목데이터 날짜 동적화

## 개요

홈 v2 페이지 적용에 따른 UI 수정 및 빌드 오류 수정, MSW 목데이터 날짜를 실행 시점 기준으로 동적화한 PR입니다.

---

## 변경 사항

### 🐛 Bug Fix

- **`CharacterSection`**: 팀 미설정 유저(`baseballTeam === null`)일 때 `teamName`이 `null`로 반환되던 문제 수정 → `TEAMS['NONE']` 폴백 적용
- **`HomePage` / `RecordMainPage`**: `onPressBack` → `backButton.onClick` API 변경으로 인한 빌드 에러 수정

### 🔧 Chore

- **`match.ts` / `recording.ts`**: 목데이터 날짜를 하드코딩된 값에서 `new Date().toISOString().slice(0, 10)` 기반 동적 계산으로 변경, 매일 수동 수정 불필요

### 🎨 Style

- **`HomePageV2`**: `React.CSSProperties` → `CSSProperties` named import로 변경
- **`HomePageV2`**: `onViewAllMatches` 콜백 포맷 정리 (줄바꿈)
- **`HomePage` / `RecordMainPage`**: import 순서 정리

---

## 주요 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `features/home/ui/CharacterSection.tsx` | 팀 미설정 시 NONE 폴백 처리 |
| `pages/home/ui/HomePage.tsx` | backButton API 수정, import 정렬 |
| `pages/home/ui/HomePageV2.tsx` | CSSProperties import 방식 변경, 코드 포맷 |
| `pages/record/ui/RecordMainPage.tsx` | backButton API 수정, import 정렬 |
| `mocks/data/match.ts` | 오늘 날짜 동적 계산 |
| `mocks/data/recording.ts` | 오늘 날짜 동적 계산 |

---

## 테스트

- [ ] 팀 미설정 유저로 홈 접속 시 캐릭터 섹션 정상 렌더 확인
- [ ] 뒤로가기 버튼 동작 확인 (홈, 관람로그 페이지)
- [ ] MSW 활성화 환경에서 오늘 날짜 기준 경기 데이터 노출 확인
