### PR TITLE
🔧 Chore : Claude Code 팀 워크플로우 및 프로젝트 컨텍스트 도입

### DIFF
--- a/.claude/commands/commit-pr.md
+++ b/.claude/commands/commit-pr.md
@@ -1,0 +1,133 @@
+---
+description: 변경사항을 논리 단위로 분할해 atomic commit 생성 후 PR까지 올린다 (Ballog 컨벤션 준수)
+argument-hint: [--base <branch>] [--dry-run] [--no-pr] [--draft]
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(pnpm lint:*), Read, Grep, Glob
+---
+
+현재 브랜치의 커밋되지 않은 변경 + 푸시되지 않은 커밋을 분석해 논리 단위 atomic commit으로 분할 후 PR을 생성한다.
+
+자동 참조 스킬: `ballog-pr-style`, `ballog-fsd-conventions`.
+
+## 인자
+- `--base <branch>` — PR base 브랜치 (기본 `develop`)
+- `--dry-run` — 커밋 계획만 출력하고 종료 (실제 커밋/푸시 X)
+- `--no-pr` — 커밋·푸시만 하고 PR 생성 건너뜀
+- `--draft` — PR을 draft로 생성
+
+## 1. 사전 검증
+
+```bash
+git status
+git branch --show-current
+git log <base>..HEAD --oneline   # 이미 있는 unpushed 커밋
+```
+
+- **브랜치 체크**: 현재 브랜치가 `main`/`master`/`develop` 이면 **중단**. 작업용 feature 브랜치로 이동/생성 요구
+- **빈 변경 체크**: uncommitted + unpushed 모두 없으면 종료
+- **base 브랜치 fetch**: `git fetch origin <base> --quiet`
+
+## 2. 변경 분석
+
+```bash
+git diff --stat                  # unstaged
+git diff --cached --stat         # staged
+git diff                         # unstaged 본문
+git diff --cached                # staged 본문
+```
+
+이미 커밋된 unpushed 히스토리가 있으면:
+- `git log <base>..HEAD --format='%h %s'` 로 목록 확인
+- 기존 커밋은 **유지** (재구성 안 함). 새 변경만 분할 대상.
+
+## 3. 커밋 계획 생성
+
+아래 기준으로 논리 단위 그룹화:
+
+| 분류 | 판별 힌트 | prefix |
+|---|---|---|
+| Feature | 신규 파일 + features/pages 추가 | `✨ Feat : ...` |
+| Style (UI) | `.tsx` className / CSS만 변경 | `💄 Style : ...` |
+| Fix (QA) | 기존 파일 소폭 수정 + 버그 성격 | `fix: ...` |
+| Refactor | 이동/이름변경/구조 변경 | `♻️ Refactor : ...` |
+| Docs | `.md` / 주석만 | `📝 Docs : ...` |
+| Chore | 설정/의존성 | `🔧 Chore : ...` |
+
+**그룹 분할 규칙**:
+- 동일 slice(FSD) 내 변경은 한 커밋에 모으기
+- 서로 다른 feature/domain 섞지 않기
+- `mocks/` + 관련 `entities/` 는 같은 커밋 (MSW-entity 짝)
+- 한 커밋 파일 수 15개 초과 시 분할 후보
+
+메시지는 `ballog-pr-style` 컨벤션:
+- 한국어 명사형, 60자 내외
+- 이모지 스타일(Feat/Style/Refactor) vs 간결(`fix:`) 혼용 금지 — 한 PR 내 통일
+
+**출력 형식** (사용자 승인용):
+
+```
+커밋 계획 (n개):
+
+[1/n] ✨ Feat : 감정 기록 엔티티 스캐폴딩
+  A  apps/web/src/entities/emotion-v2/api/emotion-v2.api.ts
+  A  apps/web/src/entities/emotion-v2/model/emotion-v2.type.ts
+  ...
+
+[2/n] 💄 Style : 홈 카드 간격 조정
+  M  apps/web/src/widgets/home/ui/TodayCard.tsx
+
+진행할까요? (yes / edit / abort)
+```
+
+## 4. 사용자 승인
+
+- `yes` → 실행
+- `edit` → 사용자가 계획 수정 의견 제시 → 재계획
+- `abort` → 종료
+- `--dry-run`이면 승인 없이 종료
+
+## 5. 커밋 실행
+
+각 그룹마다:
+```bash
+git add <group-files>           # -A, . 금지. 파일 명시
+git commit -m "<message>"       # 민감 파일(.env 등) 섞이면 경고
+```
+
+- 커밋 훅 실패 시 **중단**하고 원인 보고. `--no-verify` 금지.
+- 한 커밋이라도 실패하면 이후 그룹 보류, 상태 리포트.
+
+## 6. Push
+
+```bash
+git push -u origin <current-branch>
+```
+
+- 이미 upstream 있으면 일반 push
+- `--force` 계열 금지
+
+## 7. PR 생성 (`--no-pr` 없을 때)
+
+- `gh pr list --head <current-branch> --base <base>` 로 기존 PR 확인
+- 있으면 업데이트만, 없으면 신규 생성
+- **본문 생성**: `/review-pr` 과 동일 로직 (`ballog-pr-style` 템플릿, 전체 커밋 기반 Summary)
+- `gh pr create --base <base> --title "<title>" --body "$(cat <<'EOF' ... EOF)"`
+- `--draft` 있으면 `--draft` 플래그 추가
+
+**Title** 규칙:
+- 70자 이하
+- 가장 비중 큰 그룹의 prefix + 간결 요약 (예: `✨ Feat : 감정 기록 기능 추가`)
+
+## 8. 최종 리포트
+
+- 🟢 생성된 커밋 목록 + hash
+- 🟢 push 결과
+- 🟢 PR URL (생성한 경우)
+- 🟡 건너뛴 파일 (민감/대용량)
+- 🔴 실패한 단계 (있으면)
+
+## 안전 규칙
+
+- `git push --force` 계열, `--no-verify`, `git add -A`/`git add .` **금지**
+- `.env`, `*.pem`, `credentials*` 등 민감 파일 감지 시 사용자에게 경고 + 제외
+- 커밋 메시지는 HEREDOC으로 전달 (포맷 보존)
+- 불확실하면 중단하고 질문

--- a/.claude/commands/feat-new.md
+++ b/.claude/commands/feat-new.md
@@ -1,0 +1,94 @@
+---
+description: API 명세 MD를 읽어 entity 슬라이스 + MSW mock + (선택) Figma 기반 UI 초안까지 자동 스캐폴딩
+argument-hint: <feature-name> [--figma <url>] [--layer widgets|features|pages] [--dry-run] [--overwrite]
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(pnpm:*), Bash(git:*)
+---
+
+`docs/specs/$1.md` 의 YAML 블록을 파싱해 Ballog(apps/web) 규칙대로 entity + MSW + (선택) UI 초안을 생성한다.
+
+자동 참조 스킬: `ballog-spec-format`, `ballog-entity-template`, `ballog-msw-template`, `ballog-fsd-conventions`, `ballog-tailwind-cn`.
+
+## 인자
+- `$1` — feature name (필수). `docs/specs/$1.md` 를 spec으로 사용
+- `--figma <url>` — Figma URL. 있으면 `mcp__figma-remote-mcp__get_design_context` 로 디자인 읽어 UI 초안 생성
+- `--layer widgets|features|pages` — UI 배치 레이어 (기본 `widgets`)
+- `--dry-run` — 생성 예정 파일 목록만 출력하고 종료
+- `--overwrite` — 기존 슬라이스 덮어쓰기 (없으면 질문)
+
+## 1. Spec 로딩
+- `docs/specs/$1.md` 읽기. 없으면 에러 + `docs/specs/_example.md` 참조 안내
+- 첫 ` ```yaml ` 블록 파싱 (`ballog-spec-format` 참조)
+- 필수 필드 확인: `domain`, `endpoints[]`, `types`
+- 네이밍 정규화:
+  - `kebab` = `domain` 값 그대로 (kebab-case)
+  - `camel` = kebab → camelCase (`emotion-v2` → `emotionV2`)
+  - `Pascal` = 첫 글자 대문자 (`EmotionV2`)
+
+## 2. 사전 검증
+- `apps/web/src/entities/<kebab>/` 존재 여부
+- `apps/web/src/mocks/handlers/<camel>Handlers.ts` 존재 여부
+- 있고 `--overwrite` 없으면 **append / overwrite / abort** 질문
+- `--dry-run`이면 생성 예정 파일 트리 출력 후 종료
+
+## 3. Entity 스캐폴딩 → `apps/web/src/entities/<kebab>/`
+
+| 파일 | 내용 |
+|---|---|
+| `model/<camel>.type.ts` | spec `types` + endpoint별 Request/Response DTO |
+| `api/<camel>.api.ts` | ky 기반 HTTP method 그룹 (`<camel>Get` / `<camel>Post` / `<camel>Patch` / `<camel>Delete`) |
+| `api/<camel>.queries.ts` | `createQueryKeys('<camel>', {...})` |
+| `api/index.ts` | `export * from './<camel>.api' / '.queries'` (서브 barrel) |
+| `model/index.ts` | `export * from './<camel>.type'` (서브 barrel) |
+| `hooks/use<Pascal><Endpoint>Query.ts` | GET endpoint → `useQuery` |
+| `hooks/use<Pascal><Endpoint>Mutation.ts` | 기타 method → `useMutation` + `invalidates` 처리 |
+| `hooks/index.ts` | 훅 서브 barrel |
+| `index.ts` | 루트 barrel. `./api`, `./hooks` (+ ui 있으면 `./ui`) 만 export. `./model` 은 관례상 제외 |
+
+구체 템플릿은 `ballog-entity-template` 참조. 기준: `entities/auth/*`.
+
+## 4. MSW 스캐폴딩 → `apps/web/src/mocks/`
+
+| 파일 | 내용 |
+|---|---|
+| `handlers/<camel>Handlers.ts` | endpoint별 `http.<method>` + `delay` |
+| `data/<camel>.ts` | default fixture + `msw.scenarios` |
+| `handlers.ts` (수정) | import 1줄 + 배열 spread 1줄 (파일 **말미**에 append) |
+
+구체 템플릿은 `ballog-msw-template` 참조. 기준: `mocks/handlers/authHandlers.ts`, `mocks/data/auth.ts`.
+
+**`handlers.ts` 수정 방식**:
+- Read로 먼저 읽고, 마지막 import 줄 다음 + `handlers` 배열 닫는 `]` 바로 위에 Edit로 삽입 (**append-order**, 알파벳 순 아님)
+- 기존 포맷(따옴표·공백) 보존
+- 후처리에서 `pnpm lint --fix` 실행 (이 파일은 동일 상대경로 그룹이라 재정렬 안 됨)
+
+## 5. UI 스캐폴딩 (선택)
+
+**`--figma <url>` 있거나 spec에 `figma:` 있을 때**:
+1. URL에서 `fileKey`/`nodeId` 파싱 후 `mcp__figma-remote-mcp__get_design_context` 호출
+2. React+Tailwind 참조 코드 수신 → ballog 규칙으로 리라이트:
+   - `cn` 임포트 (`@/shared/lib/classnames`)
+   - 긴 className 줄바꿈 분해, 조건부는 bool 인자 (`ballog-tailwind-cn` 참조)
+   - `@/shared/ui/*` 의 기존 컴포넌트 재사용 (Grep으로 확인)
+   - import 순서 (외부 → alias → 상대)
+3. 레이어별 배치:
+   - `widgets` → `apps/web/src/widgets/<kebab>/ui/<Pascal>.tsx`
+   - `features` → `apps/web/src/features/<kebab>/ui/<Pascal>.tsx`
+   - `pages` → `apps/web/src/pages/<kebab>/ui/<Pascal>Page.tsx`
+4. 3단계에서 만든 첫 GET `use*Query` 훅을 import해 loading/error/empty 분기 연결
+
+**없을 때**: 빈 컨테이너 + query 훅 연결된 3상태 boilerplate만 생성.
+
+## 6. 후처리
+- `pnpm lint --fix`
+- `pnpm --filter web exec tsc --noEmit` — 실패해도 중단 X, 리포트 상단에 🔴
+- 최종 리포트:
+  - 🟢 생성된 파일 트리
+  - 🟡 수정된 파일 (`mocks/handlers.ts`)
+  - 🔴 lint/typecheck 실패 요약
+  - 다음 수동 단계 안내 (실제 비즈니스 로직 연결, 스토리 추가 등)
+
+## 규칙
+- 기존 파일은 `--overwrite` 없이 덮어쓰지 않음
+- 확실치 않으면 중단하고 질문
+- 생성 직후 `<camel>.type.ts` 1개를 Read로 자가 점검
+- 객체지향 관점 유지: view(UI 컴포넌트)와 로직(hooks) 분리, 한 파일 단일 책임

--- a/.claude/commands/review-local.md
+++ b/.claude/commands/review-local.md
@@ -1,0 +1,25 @@
+---
+description: 커밋 전 staged diff 빠른 리뷰 (리포트만, PR 본문 없음)
+allowed-tools: Bash(git:*), Read, Grep
+---
+
+`git diff --cached` 내용만 대상으로 빠르게 리뷰한다. PR 본문은 생성하지 않는다.
+
+관련 스킬이 있으면 자동 참조: `ballog-fsd-conventions`, `ballog-tailwind-cn`.
+
+## 수집
+- `git diff --cached --stat`
+- `git diff --cached` 전체 본문
+- staged가 비어있으면 즉시 종료하고 안내
+
+## 리뷰 기준
+`/review-pr` 과 동일 — SRP / ISP / View-로직 분리 / Tailwind + cn / FSD 경계.
+
+## 출력
+- 🔴 / 🟡 / 🟢 버킷 리포트
+- 각 항목: `path:line` — 문제 + 한 줄 제안
+- 마지막 줄: must-fix가 없으면 ✅ `커밋 OK`, 있으면 🔴 `커밋 보류 권장 (n건)`
+
+## 주의
+- 빠른 피드백 우선 — 파일당 핵심 이슈 위주로 압축
+- 포맷/스페이스 수준 지적은 생략 (lint가 담당)

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,84 @@
+---
+description: 현재 브랜치 vs develop 전체 diff 리뷰 후 PR 본문 생성 (OOP/FSD/Tailwind 기준)
+argument-hint: [base-branch] [--skip-lint]
+allowed-tools: Bash(git:*), Bash(pnpm lint:*), Read, Grep, Glob
+---
+
+현재 브랜치와 base 브랜치(`$1` 또는 기본 `develop`) 사이의 모든 변경을 리뷰하고 PR 본문까지 생성한다.
+
+관련 스킬이 있으면 자동 참조: `ballog-fsd-conventions`, `ballog-tailwind-cn`, `ballog-pr-style`.
+
+## 1. 변경 수집
+- `git fetch origin <base> --quiet`
+- `git log <base>..HEAD --oneline` 으로 커밋 목록 확보
+- `git diff <base>...HEAD --stat` 으로 파일 변경 요약
+- 주요 변경 파일은 `git diff <base>...HEAD -- <file>` 로 전체 내용 확인
+
+## 2. lint (옵션)
+- `$2`가 `--skip-lint`가 아니면 `pnpm lint` 실행
+- 실패 시 에러 요약을 리포트 최상단에 표시
+
+## 3. 코드 리뷰 (객체지향 관점)
+
+심각도: 🔴 must-fix / 🟡 should-fix / 🟢 nit. 각 항목은 `path:line — 문제 + 제안` 형태.
+
+### SRP — 단일 책임
+- 컴포넌트 한 파일에서 뷰 + fetch + 상태 가공이 섞였는가
+- `useEffect` 한 블록에 역할 2개 이상 섞였는가
+- 파일 300줄↑, 함수 50줄↑ 플래그
+
+### ISP — 인터페이스 분리
+- Props 타입 7개 이상 → 쪼갤 수 있는지
+- 특정 분기에서만 쓰는 optional prop이 많다 → 컴포넌트 분리 후보
+- `any`, 과도한 `Partial<>`, 임의 union 남발
+
+### View ↔ 로직 분리
+- JSX 파일 안에 비즈니스 로직/파생 상태 계산 → `use*` 훅 추출 제안
+- API 호출·localStorage·날짜 포맷팅이 컴포넌트 내부에 있으면 `shared/lib`로 추출
+- `features/*` 에 JSX 직접 렌더링이 비대 → `widgets`/`pages`로 이동 후보
+
+### Tailwind + cn
+- 긴 className / 조건부 분기 → `cn(...)` + bool 인자로 가독성 개선
+- 동일 variant 반복 → 상수/맵 추출
+- 외부 `className` prop은 `cn` 마지막 인자 (override 가능해야 함)
+- import: `import { cn } from '@/shared/lib/classnames'`
+
+### FSD 경계
+- 하위 레이어가 상위 레이어를 import (app → pages → widgets → features → entities → shared 순서 역행)
+- 같은 레이어 수평 참조 (shared 제외)
+- `index.ts` 공개 API 우회 deep import
+
+## 4. 출력 (2단 구성)
+
+### 파트 A — 리뷰 리포트
+- 🔴 / 🟡 / 🟢 버킷별 그룹
+- 각 항목: `path/to/file.tsx:L23` — 문제 설명 + 한 줄 제안
+- 말미에 카운트: must-fix n / should-fix n / nit n
+
+### 파트 B — PR 본문
+`.github/PULL_REQUEST_TEMPLATE.md` 포맷을 지키되, 커밋 이모지(`✨ Feat` / `💄 Style` / `✏️ Fix` / `♻️ Refactor`)를 감지해 Summary 섹션을 분류한다. 없으면 `fix:` / `feat:` prefix 사용.
+
+```
+## Summary
+
+- ✨ 추가: <요약>
+- 💄 스타일: <요약>
+- ✏️ 수정: <요약>
+- ♻️ 리팩터: <요약>
+
+<변경 동기 1–3줄>
+
+## How did you test this change?
+
+- [ ] `pnpm lint` 통과
+- [ ] `pnpm --filter web build` 통과
+- [ ] 수동 QA: <확인 항목>
+- [ ] 스크린샷/영상 (UI 변경 시)
+```
+
+톤: 한국어, 명사형 종결, bullet 한 줄 60자 내외, 빈 섹션은 삭제.
+
+## 주의사항
+- diff가 크면 파일 그룹별로 나눠 리뷰 (섣부른 결론 금지)
+- 파일 삭제만 있는 변경은 테스트 섹션에서 빌드/타입체크만 요구
+- lint 실패는 🔴로 올려 PR 본문 테스트 체크박스 해제

--- a/.claude/hooks/pre-commit-review.sh
+++ b/.claude/hooks/pre-commit-review.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Enforce /review-pr before git commit.
+# Allow when .git/.claude-review-ok contains sha256 of current staged diff.
+set -u
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+
+if ! printf '%s' "$cmd" | grep -Eq '(^|[[:space:];&|])git[[:space:]]+commit($|[[:space:]])'; then
+  exit 0
+fi
+
+staged_hash=$(git diff --cached 2>/dev/null | shasum -a 256 | awk '{print $1}')
+marker=".git/.claude-review-ok"
+
+if [ -f "$marker" ] && [ "$(cat "$marker" 2>/dev/null)" = "$staged_hash" ]; then
+  rm -f "$marker"
+  exit 0
+fi
+
+jq -n --arg hash "$staged_hash" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: ("커밋 차단됨: /review-pr 을 먼저 실행하세요.\n\n리뷰 후 blocker가 없으면 다음 명령으로 마커 생성 후 다시 커밋:\n  git diff --cached | shasum -a 256 | awk '\''{print $1}'\'' > .git/.claude-review-ok\n\n(현재 staged hash: " + $hash + ")\n마커는 해당 staged 상태에서 1회만 유효합니다.")
+  }
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "includeCoAuthoredBy": false,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/pre-commit-review.sh",
+            "if": "Bash(git commit*)",
+            "statusMessage": "checking /review-pr marker before commit"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/ballog-entity-template/SKILL.md
+++ b/.claude/skills/ballog-entity-template/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: ballog-entity-template
+description: Ballog entity 슬라이스 생성 템플릿. ky API 그룹, query-key-factory 등록, query/mutation 훅 네이밍과 invalidation 규칙. /feat-new 가 참조.
+---
+
+# Ballog Entity Slice Template
+
+기준 파일: `apps/web/src/entities/auth/*`
+
+## 디렉토리
+
+```
+apps/web/src/entities/<kebab>/
+├── api/
+│   ├── <camel>.api.ts
+│   ├── <camel>.queries.ts
+│   └── index.ts                    ← 서브 barrel
+├── model/
+│   ├── <camel>.type.ts
+│   └── index.ts                    ← 서브 barrel
+├── hooks/
+│   ├── use<Pascal><Endpoint>Query.ts
+│   ├── use<Pascal><Endpoint>Mutation.ts
+│   └── index.ts                    ← 서브 barrel
+├── ui/                             (UI 있을 때만)
+│   └── index.ts                    ← 서브 barrel
+└── index.ts                        ← 루트 barrel
+```
+
+**barrel 규칙** (프로젝트 관례):
+- 각 서브디렉토리에 `index.ts` 로 내부 파일을 `export *` 로 공개
+- 루트 `index.ts` 는 서브디렉토리 barrel만 export (개별 파일 참조 X)
+- 참고: `entities/auth/index.ts` 는 `./ui`, `./api` 만 export. 외부에서 `model/` 타입을 직접 쓰려면 deep path 사용 (예: `@/entities/auth/model/auth.type`)
+
+## `model/<camel>.type.ts`
+
+```ts
+import type {
+  ApiResponse,
+  ApiResponseWithNoSuccess,
+} from '@/types/api/common'
+
+export interface Emotion {
+  id: number
+  type: 'HAPPY' | 'SAD'
+  createdAt: string
+}
+
+export type EmotionResponseDTO = ApiResponseWithNoSuccess<Emotion[]>
+
+export interface CreateEmotionRequestDTO {
+  type: Emotion['type']
+  matchRecordId: number
+}
+```
+
+## `api/<camel>.api.ts` — ky 기반 method 그룹
+
+```ts
+import { api } from '@/shared/lib/ky'
+
+import type {
+  CreateEmotionRequestDTO,
+  EmotionResponseDTO,
+} from '../model/emotion.type'
+
+export const emotionGet = {
+  getEmotionRecord: async (
+    matchRecordId: number,
+  ): Promise<EmotionResponseDTO> => {
+    return api.get(`emotion/${matchRecordId}`).json<EmotionResponseDTO>()
+  },
+}
+
+export const emotionPost = {
+  createEmotion: async (
+    data: CreateEmotionRequestDTO,
+  ): Promise<EmotionResponseDTO> => {
+    return api.post('emotion', { json: data }).json<EmotionResponseDTO>()
+  },
+}
+```
+
+**핵심**:
+- `api` (ky instance)는 prefix에 `/api/v1` 포함 → path 선행 슬래시 제거
+- 객체 그룹핑: `<camel>Get` / `<camel>Post` / `<camel>Patch` / `<camel>Delete`
+- 반환 타입 명시 필수 (암묵 추론 금지)
+
+## `api/<camel>.queries.ts`
+
+```ts
+import { createQueryKeys } from '@lukemorales/query-key-factory'
+
+import { emotionGet } from './emotion.api'
+
+export const emotionQueries = createQueryKeys('emotion', {
+  getEmotionRecord: (matchRecordId: number) => ({
+    queryKey: [matchRecordId],
+    queryFn: () => emotionGet.getEmotionRecord(matchRecordId),
+  }),
+})
+```
+
+- factory 변수명: `<camel>Queries`
+- scope 키: `'<camel>'` (문자열 리터럴)
+
+## `hooks/use<Pascal><Endpoint>Query.ts`
+
+```ts
+import { useQuery } from '@tanstack/react-query'
+
+import { emotionQueries } from '../api/emotion.queries'
+
+export const useGetEmotionRecordQuery = (matchRecordId: number) => {
+  return useQuery({
+    ...emotionQueries.getEmotionRecord(matchRecordId),
+    enabled: matchRecordId > 0,
+  })
+}
+```
+
+- 훅 한 파일에 하나 (SRP)
+- `enabled` 기본 규칙: path param이 falsy면 비활성화
+
+## `hooks/use<Pascal><Endpoint>Mutation.ts`
+
+```ts
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { emotionPost } from '../api/emotion.api'
+import { emotionQueries } from '../api/emotion.queries'
+
+export const useCreateEmotionMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: emotionPost.createEmotion,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: emotionQueries.getEmotionRecord._def,
+      })
+    },
+  })
+}
+```
+
+- `invalidates: [a, b]` → `invalidateQueries` 두 번 또는 `_def` 배열 loop
+- optimistic update는 기본 템플릿에 포함하지 않음 (필요 시 수동 추가)
+
+## Barrel 파일들
+
+### `api/index.ts`
+```ts
+export * from './emotion.api'
+export * from './emotion.queries'
+```
+
+### `model/index.ts`
+```ts
+export * from './emotion.type'
+```
+
+### `hooks/index.ts`
+```ts
+export * from './useGetEmotionRecordQuery'
+export * from './useCreateEmotionMutation'
+```
+
+### `ui/index.ts` (UI 생성 시)
+```ts
+export * from './EmotionCard'
+// ...각 컴포넌트
+```
+
+### 루트 `index.ts`
+```ts
+export * from './api'
+export * from './hooks'
+// ui 있으면 추가:
+// export * from './ui'
+```
+
+**규칙**:
+- 루트 barrel은 서브디렉토리 barrel만 참조 (개별 파일 X)
+- `model` 은 관례상 루트 barrel에 넣지 않음 (실제 `auth/index.ts` 패턴). 타입이 필요한 외부 코드는 `@/entities/<kebab>/model/<camel>.type` 로 deep import
+- `mocks/`는 인프라 레이어라 model deep import 허용 (`ballog-fsd-conventions` 의 예외 조항)
+
+## import 순서 (ESLint 강제)
+
+1. 외부 (`react`, `@tanstack/react-query`, ...)
+2. alias (`@/shared/...`, `@/types/...`)
+3. 상대 (`./`, `../`)
+
+각 블록 사이 빈 줄 1칸.
+
+## 리뷰 플래그
+
+- 🔴 반환 타입 누락 → 명시 요구
+- 🔴 서브디렉토리 barrel 누락 (`api/index.ts`, `hooks/index.ts` 등) → 참조 깨짐
+- 🔴 루트 barrel에 개별 파일 참조 → 서브 barrel 경유로 변경
+- 🟡 훅 한 파일에 여러 개 → 파일 분리
+- 🟡 mutation에 `invalidateQueries` 없음 → spec `invalidates` 확인

--- a/.claude/skills/ballog-fsd-conventions/SKILL.md
+++ b/.claude/skills/ballog-fsd-conventions/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: ballog-fsd-conventions
+description: Ballog(apps/web) FSD 레이어 규칙. 의존 방향, public API, import 순서, 네이밍. 파일 생성/리뷰 시 경계 위반 검증에 사용.
+---
+
+# Ballog FSD 컨벤션
+
+## 레이어 순서 (상 → 하)
+
+```
+app → pages → widgets → features → entities → shared
+```
+
+- 상위 레이어는 하위만 import
+- **역방향 import 금지**
+- 같은 레이어 수평 참조 금지 (shared 제외)
+
+## 위치
+
+- `apps/web/src/app` — 앱 초기화, provider, 라우터
+- `apps/web/src/pages` — 라우트 화면 (auth / community / home / live-recording / mypage / onBoarding / record / term)
+- `apps/web/src/widgets` — 여러 feature를 합성한 UI 블록
+- `apps/web/src/features` — 사용자 액션 단위 (로그인, 친구 추가 등)
+- `apps/web/src/entities` — 도메인 모델 단위 UI/스토어
+- `apps/web/src/shared` — 공용 lib / ui / config
+
+## Public API (`index.ts`)
+
+각 슬라이스는 `index.ts`로만 외부에 공개한다.
+
+```
+features/add-friend/
+├── ui/AddFriendSheet.tsx
+├── model/useAddFriend.ts
+└── index.ts   ← export { AddFriendSheet }
+```
+
+외부에서 `features/add-friend/ui/AddFriendSheet` 직접 deep import 금지.
+
+## Import 순서 (ESLint 강제)
+
+1. 외부 패키지 (`react`, 라이브러리)
+2. 절대경로 alias (`@/app`, `@/pages`, `@/widgets`, ...)
+3. 상대경로 (`./`, `../`)
+
+각 블록 사이 빈 줄 1칸.
+
+## 공용 유틸
+
+```ts
+import { cn } from '@/shared/lib/classnames'
+```
+
+## 파일 네이밍
+
+- 컴포넌트 파일: `PascalCase.tsx`
+- 훅: `useXxx.ts`
+- 유틸/상수: `camelCase.ts`
+- 슬라이스 디렉토리: 기존 관례 유지 (현재 `kebab-case` / `camelCase` 혼재 — PR에서 통일 제안)
+
+## 리뷰 플래그
+
+- 🔴 하위 레이어가 상위 레이어를 import (예: `entities` → `features`)
+- 🔴 `index.ts` 우회 deep import (예: `features/foo/ui/Bar`)
+- 🟡 같은 레이어 수평 참조 (shared 제외)
+- 🟡 import 순서 위반 (최근 커밋 `8ade176`에서 발생한 유형)
+- 🟢 디렉토리 네이밍 혼재

--- a/.claude/skills/ballog-msw-template/SKILL.md
+++ b/.claude/skills/ballog-msw-template/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: ballog-msw-template
+description: Ballog MSW handler/data 생성 템플릿과 handlers.ts 레지스트리 삽입 규칙. /feat-new 가 참조.
+---
+
+# Ballog MSW Template
+
+기준 파일: `apps/web/src/mocks/handlers/authHandlers.ts`, `apps/web/src/mocks/data/auth.ts`
+
+## 디렉토리
+
+```
+apps/web/src/mocks/
+├── handlers.ts                   (수정 — 레지스트리)
+├── handlers/
+│   └── <camel>Handlers.ts        (생성)
+└── data/
+    └── <camel>.ts                (생성)
+```
+
+## `handlers/<camel>Handlers.ts`
+
+```ts
+import { http, HttpResponse, delay } from 'msw'
+
+import type {
+  CreateEmotionRequestDTO,
+  EmotionResponseDTO,
+} from '@/entities/emotion/model/emotion.type'
+import type { ApiErrorMessage } from '@/types/api/common'
+
+import { emotion } from '@/mocks/data/emotion'
+
+const EMOTION_API_PREFIX = `${import.meta.env.VITE_PUBLIC_API_URL}/api/v1/emotion`
+
+export const emotionHandlers = [
+  http.get<
+    { matchRecordId: string },
+    never,
+    EmotionResponseDTO | ApiErrorMessage
+  >(`${EMOTION_API_PREFIX}/:matchRecordId`, async () => {
+    await delay(emotion.delay)
+    return HttpResponse.json<EmotionResponseDTO>({ data: emotion.records })
+  }),
+
+  http.post<
+    never,
+    CreateEmotionRequestDTO,
+    EmotionResponseDTO | ApiErrorMessage
+  >(EMOTION_API_PREFIX, async ({ request }) => {
+    const body = await request.json()
+    await delay(emotion.delay)
+
+    // msw.scenarios[*] 의 when 분기
+    if (body.matchRecordId === 0) {
+      return HttpResponse.json<ApiErrorMessage>(
+        {
+          error: 'invalid match',
+          status: 400,
+          code: 'INVALID_MATCH',
+          message: 'invalid match',
+        },
+        { status: 400 },
+      )
+    }
+
+    return HttpResponse.json<EmotionResponseDTO>({ data: emotion.records })
+  }),
+]
+```
+
+**핵심**:
+- 배열 이름: `<camel>Handlers`
+- `http.<method>` 제네릭: `<PathParams, RequestBody, ResponseBody>`
+- URL prefix 상수: `${VITE_PUBLIC_API_URL}/api/v1/<path-root>`
+- `delay` 는 data 파일의 `delay` 필드를 참조 (일관성)
+- 시나리오는 handler 상단에서 분기 → 기본 응답은 말미에 반환
+
+## `data/<camel>.ts`
+
+```ts
+import type { Emotion } from '@/entities/emotion/model/emotion.type'
+
+export const emotion: {
+  delay: number
+  records: Emotion[]
+} = {
+  delay: 1500,
+  records: [
+    { id: 1, type: 'HAPPY', createdAt: '2024-01-01T00:00:00Z' },
+  ],
+}
+```
+
+- fixture 변수명: `<camel>` (도메인명 그대로)
+- 타입 명시 (엄격)
+- scenarios 전용 필드가 필요하면 객체 확장
+
+## `handlers.ts` 레지스트리 수정
+
+실제 파일 예시 (순서는 **append-order**, 알파벳 아님):
+
+```ts
+import { authHandlers } from './handlers/authHandlers'
+import { matchHandlers } from './handlers/matchHandlers'
+import { emotionHandlers } from './handlers/emotionHandlers'
+import { userHandlers } from './handlers/userHandlers'
+// ...
+
+export const handlers = [
+  ...authHandlers,
+  ...matchHandlers,
+  ...emotionHandlers,
+  // ...
+]
+```
+
+삽입 규칙:
+1. **import 블록 말미**: 마지막 `import { ...Handlers } from './handlers/...'` 줄 **다음**에 `import { <camel>Handlers } from './handlers/<camel>Handlers'` 추가
+2. **handlers 배열 말미**: 마지막 `...xxxHandlers,` 줄 **다음**에 `...<camel>Handlers,` 추가
+3. **후처리**: `pnpm lint --fix` — import 순서는 이 파일 형태상 재정렬되지 않음 (동일 상대경로 그룹). 안전.
+
+구현은 AST 아닌 Edit 기반 문자열 삽입으로. 마지막 import 줄 / `export const handlers = [` 블록 닫는 `]` 을 anchor로 잡아 말미 삽입.
+
+## 리뷰 플래그
+
+- 🔴 `handlers.ts` 에 등록 누락 → mock 동작 안 함
+- 🔴 제네릭 타입 누락 (`http.get<...>`) → 타입 안전성 손실
+- 🟡 `delay` 하드코딩 (data 파일 참조 없이) → 일관성 깨짐
+- 🟡 scenarios 분기 누락 → spec에 있으면 추가

--- a/.claude/skills/ballog-pr-style/SKILL.md
+++ b/.claude/skills/ballog-pr-style/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: ballog-pr-style
+description: Ballog 커밋 및 PR 메시지 컨벤션. 이모지 prefix(✨Feat/💄Style/✏️Fix)와 fix:/feat: 간결 스타일 혼용 규칙, 한국어 PR 본문 작성 틀. /review-pr 이 참조.
+---
+
+# Ballog 커밋 & PR 스타일
+
+## 커밋 prefix (혼재 스타일)
+
+최근 히스토리상 두 스타일이 공존한다.
+
+**이모지 스타일** — 기능/스타일/리팩터 작업
+
+- `✨ Feat : 친구 추가 바텀시트 키보드 자동 오픈`
+- `💄 Style : 관람로그 버튼 스타일 작업`
+- `✏️ Fix : default -> named export 로 수정`
+- `♻️ Refactor : …`
+
+**간결 스타일** — QA 수정 / 긴급 픽스
+
+- `fix: TodayMatchCard import 순서 lint 에러 수정`
+- `fix: 커뮤니티 빈 상태 이미지를 SVG 컴포넌트로 교체`
+
+### 선택 기준
+
+- QA / 버그픽스 / 긴급 수정 → `fix: ...`
+- 신규 기능 / 스타일 / 리팩터 → 이모지 스타일
+- **한 PR 내에서 두 스타일 섞지 말 것**
+
+## PR 본문 템플릿
+
+`.github/PULL_REQUEST_TEMPLATE.md` 기반:
+
+```
+## Summary
+
+- ✨ 추가: <요약>
+- 💄 스타일: <요약>
+- ✏️ 수정: <요약>
+- ♻️ 리팩터: <요약>
+
+<변경 동기 1–3줄. 왜 이 변경이 필요했는지.>
+
+## How did you test this change?
+
+- [ ] `pnpm lint` 통과
+- [ ] `pnpm --filter web build` 통과
+- [ ] 수동 QA: <확인 항목>
+- [ ] 스크린샷/영상 (UI 변경 시)
+```
+
+## 톤 & 포맷
+
+- **한국어**, 명사형 종결 ("…추가", "…수정")
+- bullet 한 줄 60자 내외
+- 해당 없는 섹션 bullet은 삭제
+- Summary 이모지와 본문 bullet 이모지는 일치시켜 일관성
+
+## 리뷰 플래그
+
+- 🟡 테스트 방법 섹션 비어있음 (템플릿상 closed 위험)
+- 🟡 Summary가 커밋 메시지 1줄 복붙 수준 → 동기 문장 추가
+- 🟢 이모지/간결 스타일 혼재 → 통일 제안

--- a/.claude/skills/ballog-spec-format/SKILL.md
+++ b/.claude/skills/ballog-spec-format/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: ballog-spec-format
+description: /feat-new 가 읽는 Ballog API 명세 MD의 YAML 스키마 정의. endpoints/types/msw/figma 필드와 작성 규칙. spec 파일 작성이나 파싱할 때 참조.
+---
+
+# Ballog API Spec Format
+
+`docs/specs/<feature>.md` 안에 첫 ` ```yaml ` 코드 블록으로 작성한다. 첫 블록 외에는 무시.
+
+## 스키마
+
+```yaml
+domain: emotion-v2                  # 필수. kebab-case 권장. entity 슬라이스 디렉토리 이름
+layer: widgets                      # 선택. widgets(기본) | features | pages
+figma: https://figma.com/design/... # 선택. --figma 생략 시 사용
+
+endpoints:                          # 필수. 1개 이상
+  - name: getEmotionRecord          # camelCase. 훅 이름 = use<Pascal>Query
+    method: GET                     # GET | POST | PATCH | PUT | DELETE
+    path: /emotion/:matchRecordId   # 선행 슬래시, 경로 파라미터는 :name
+    params:                         # 선택. path/query 파라미터
+      matchRecordId: number
+    response: EmotionResponseDTO    # types의 이름 or TS 문자열
+
+  - name: createEmotion
+    method: POST
+    path: /emotion
+    request: CreateEmotionRequestDTO
+    response: EmotionResponseDTO
+    invalidates: [getEmotionRecord] # 선택. mutation 성공 시 invalidate할 query name
+
+types:                              # 필수
+  Emotion:
+    id: number
+    type: "'HAPPY' | 'SAD' | 'ANGRY'"   # 유니온/리터럴은 문자열로 감싸기
+    createdAt: string
+  EmotionResponseDTO: "ApiResponseWithNoSuccess<Emotion[]>"   # 값 위치에 TS 원문 허용
+  CreateEmotionRequestDTO:
+    type: "Emotion['type']"
+    matchRecordId: number
+
+msw:                                # 선택
+  scenarios:
+    - endpoint: createEmotion       # endpoints의 name과 일치
+      when: "body.matchRecordId === 0"   # JS 표현식. `body`/`params`/`request` 참조 가능
+      status: 400
+      response: { error: "invalid match" }
+```
+
+## 작성 규칙
+
+- **타입 표현력**: 값 위치에 문자열을 주면 TypeScript 원문으로 취급. 유니온/제네릭/유틸리티 타입 전부 가능.
+- **공용 타입 자동 import**: `ApiResponse<T>`, `ApiResponseWithNoSuccess<T>`, `ApiErrorMessage`, `KyHttpError` 는 `@/types/api/common` 에서 자동 임포트.
+- **Mutation 판별**: method가 GET이 아니면 mutation 훅 생성.
+- **invalidates**: 각 name → `<camel>Queries.<name>._def` 기준으로 `invalidateQueries`.
+- **path 파라미터**: `:name` 은 `params`에 반드시 선언. 자동으로 URL 치환 + 타입 반영.
+
+## 네이밍 변환
+
+| spec `domain` | directory | file/variable base | Pascal |
+|---|---|---|---|
+| `emotion` | `emotion/` | `emotion` | `Emotion` |
+| `emotion-v2` | `emotion-v2/` | `emotionV2` | `EmotionV2` |
+| `demo-ticket` | `demo-ticket/` | `demoTicket` | `DemoTicket` |
+
+- **디렉토리**: spec 값 그대로 (kebab 허용)
+- **파일명·변수명**: camelCase 변환 (`demoTicket.api.ts`, `demoTicketGet`)
+- **클래스/타입/훅 prefix**: PascalCase (`useDemoTicketQuery`, `DemoTicketResponseDTO`)
+
+## 파싱 결과 → 생성물 매핑
+
+| spec 필드 | 생성 |
+|---|---|
+| `types.*` | `entities/<kebab>/model/<camel>.type.ts` |
+| `endpoints[].request/response` | 같은 파일에 Request/Response DTO alias 추가 |
+| `endpoints[GET]` | `<camel>Get.<name>` + `use<Pascal><Endpoint>Query` |
+| `endpoints[!GET]` | `<camel><Method>.<name>` + `use<Pascal><Endpoint>Mutation` |
+| `endpoints[].invalidates` | mutation `onSuccess` 의 `invalidateQueries` |
+| `msw.scenarios` | handler 내부 조건 분기 |
+| `figma` | `--figma` 미지정 시 fallback URL |

--- a/.claude/skills/ballog-tailwind-cn/SKILL.md
+++ b/.claude/skills/ballog-tailwind-cn/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: ballog-tailwind-cn
+description: Ballog 프로젝트의 Tailwind + cn() 사용 규칙. 조건부 클래스 가독성, twMerge 충돌 회피, 반복 유틸 추출 기준. className을 작성하거나 리뷰할 때 참조.
+---
+
+# Ballog Tailwind + cn 가이드
+
+## cn 위치
+
+```ts
+import { cn } from '@/shared/lib/classnames'
+```
+
+`clsx` + `tailwind-merge` 래퍼. 조건부 클래스와 Tailwind 충돌 해결을 동시에 처리한다.
+
+## 사용 원칙
+
+### 1. 긴 className은 줄바꿈으로 분해
+
+❌ 한 줄에 몰아넣기
+
+```tsx
+<div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-white text-gray-900 hover:bg-gray-50">
+```
+
+✅ 관심사별로 줄바꿈
+
+```tsx
+<div
+  className={cn(
+    'flex items-center gap-2',
+    'px-4 py-2 rounded-lg',
+    'bg-white text-gray-900',
+    'hover:bg-gray-50',
+  )}
+>
+```
+
+### 2. 조건부 클래스는 bool 인자
+
+✅
+
+```tsx
+className={cn(
+  'rounded-full px-3 py-1',
+  isActive && 'bg-primary text-white',
+  disabled && 'opacity-50 pointer-events-none',
+)}
+```
+
+❌ `cn` 없이 템플릿 리터럴
+
+```tsx
+className={`${base} ${isActive ? 'bg-primary' : ''}`}
+```
+
+### 3. 동일 variant 반복은 맵 상수로
+
+같은 prop → className 매핑이 2번 이상 등장하면 모듈 상단 상수로 분리.
+
+```tsx
+const sizeStyle = {
+  sm: 'h-8 px-3 text-sm',
+  md: 'h-10 px-4 text-base',
+  lg: 'h-12 px-5 text-lg',
+} as const
+
+<button className={cn('rounded-lg', sizeStyle[size])}>
+```
+
+### 4. twMerge 충돌 — 뒤가 이긴다
+
+```tsx
+cn('px-4', isLarge && 'px-8') // isLarge면 px-8만 남음
+```
+
+외부에서 받은 `className` prop은 **항상 마지막**에 둬서 오버라이드 가능하게.
+
+```tsx
+<div className={cn('base-styles', className)} />
+```
+
+## 리뷰 플래그
+
+- 🔴 외부 `className` prop을 `cn` 왼쪽에 배치 (override 불가)
+- 🟡 6줄 이상 연속된 className 문자열 → 줄바꿈 분해
+- 🟡 템플릿 리터럴로 조건부 클래스 → `cn` 전환
+- 🟡 동일 variant 매핑이 2회 이상 → 상수 추출
+- 🟢 의미 단위(layout/spacing/color/state) 무시하고 섞인 순서

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+.omc/
 
 # Build outputs
 dist
@@ -176,3 +177,5 @@ next-env.d.ts
 
 # AI
 opencode.jsonc
+.claude/settings.local.json
+WORKFLOW.md

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,394 @@
+# AGENT.md — Ballog Frontend
+
+AI 에이전트 및 개발자를 위한 프로젝트 컨텍스트 문서입니다.
+코드 작성, 리뷰, 리팩터링 전에 이 문서를 먼저 읽으세요.
+
+---
+
+## 1. 프로젝트 개요
+
+**Ballog**는 야구 직관(현장 관람) 기록 앱입니다.
+사용자가 경기를 직접 보면서 실시간으로 감정을 기록하고, 친구들과 감정을 공유하는 모바일 웹앱입니다.
+
+### 기술 스택
+
+| 분류 | 기술 |
+|------|------|
+| 프레임워크 | React 19, TypeScript 5.8 |
+| 빌드 | Vite 6, pnpm workspace (모노레포) |
+| 라우팅/내비게이션 | Stackflow (iOS Cupertino 테마) |
+| 서버 상태 | TanStack Query v5 |
+| 스타일 | Tailwind CSS v4, CVA, clsx |
+| UI 컴포넌트 | Radix UI, shadcn/ui, Framer Motion |
+| HTTP | ky |
+| 날짜 | date-fns, date-fns-tz |
+| 애니메이션 | Lottie React |
+| 차트 | Recharts |
+| 캐러셀 | Embla Carousel |
+| 모킹 | MSW v2 |
+| 테스트 | Vitest, Playwright, Testing Library |
+| 스토리북 | Storybook 9 |
+
+### 모노레포 패키지 구조
+
+```
+ballog-front/
+├── apps/
+│   └── web/                        # 메인 React 앱
+└── packages/
+    ├── asset/                      # SVG 아이콘, 이미지 에셋
+    ├── bridge/                     # 네이티브(RN) ↔ 웹 브릿지
+    ├── live-recording-machine/     # FSM 코어 라이브러리 (순수 TS)
+    ├── eslint/                     # 공유 ESLint 설정
+    ├── tsconfig/                   # 공유 TypeScript 설정
+    └── util/                       # 공유 유틸리티
+```
+
+---
+
+## 2. fix/build 브랜치 주요 작업 요약
+
+이 브랜치는 `develop` 대비 다음 기능을 구현합니다.
+
+### 2-1. 홈 V2 페이지 (`HomePageV2`)
+- 기존 `HomePage`(경기 일정 중심)를 대체하는 새 홈 화면
+- 감정 캐릭터(`CharacterSection`)가 현재 감정 상태(POSITIVE/NEGATIVE/없음)에 따라 변화
+- 오늘의 주요 경기(`TodayMatchCard`) 표시, 로딩 중에는 스켈레톤 UI
+- 현재 라우트 기준: `Home` → `HomePageV2`, `MatchSchedule` → 기존 `HomePage`
+
+### 2-2. 커뮤니티 기능 전체 구현 (⚠️ API 미연동 — 목데이터 상태)
+- 팀 순위 + 친구 감정 현황 대시보드
+- 친구 목록 그리드, 빈 상태(CTA), KBO 순위 바텀시트
+- 친구 추가 바텀시트 (키보드 자동 오픈, `visualViewport` 기반 키보드 인셋)
+- 신고 바텀시트
+- 친구 상세 페이지, 친구 요청 페이지
+- 친구 프로필 사진 바텀시트
+
+### 2-3. 라이브 레코딩 FSM 리팩터링
+- `@ballog/live-recording-machine` 워크스페이스 패키지로 FSM 코어 분리
+- `LiveRecordRuntime` 클래스로 이벤트 큐/구독 관리
+- `useSyncExternalStore` 기반 React 구독
+- Command 패턴으로 사이드이펙트(API 호출) 분리
+
+### 2-4. 바텀시트 포탈 시스템
+- `BottomSheetModal.PortalBottomSheet`: `createPortal`로 `document.body`에 마운트
+- CSS transition 기반 슬라이드 업/다운 애니메이션 (300ms)
+- Stackflow 레이어 z-index 충돌 해결
+
+### 2-5. 기타
+- KBO 10개 구단 상수 및 아이콘 매핑 (`TEAMS`, `SHORT_TEAM_NAMES`, `TEAM_ICONS`)
+- `scrollbar-hidden` Tailwind 유틸 추가
+- `.gitignore`에 AI 도구 설정 디렉터리 추가 (`.claude/`, `.omc/`)
+
+---
+
+## 3. 아키텍처 패턴
+
+### 3-1. FSM (유한 상태 머신) — 라이브 레코딩
+
+라이브 레코딩의 복잡한 상태 전이를 FSM으로 모델링합니다.
+
+**상태 전이도:**
+```
+new → recording ⇄ updating → terminate
+              ↓
+           error → (retry or terminate)
+```
+
+**상태 목록:**
+
+| 상태 | 의미 |
+|------|------|
+| `new` | 초기 로딩, 녹화 데이터 조회 중 |
+| `recording` | 활성 녹화, 3초 폴링 |
+| `updating` | 감정 업데이트 API 호출 중 |
+| `error` | API 실패, 재시도 대기 |
+| `terminate` | 경기 종료 또는 시간 만료 |
+
+**이벤트 목록 (외부 → FSM):**
+
+`INIT`, `RECORDING_FOUND`, `RECORDING_NOT_FOUND`, `CREATE_SUCCESS`, `CREATE_FAIL`,
+`EMOTION_CLICK`, `POLL_TICK_3S`, `UPDATE_SUCCESS`, `UPDATE_FAIL`,
+`TIME_EXPIRED`, `GAME_ENDED`, `RETRY`, `RETRY_EXHAUSTED`
+
+**Command 목록 (FSM → 외부):**
+
+`FETCH_OR_CREATE_RECORDING`, `CREATE_RECORDING`, `START_UPDATE_FROM_CLICK`,
+`START_UPDATE_FROM_POLL`, `SCHEDULE_RETRY`, `DO_TERMINATE`
+
+**파일 위치:**
+
+```
+packages/live-recording-machine/       ← 순수 TS, React 의존 없음
+  src/types.ts                         ← 이벤트/커맨드/스냅샷 타입 정의
+  src/context.ts                       ← LiveRecordingContext (상태 머신 코어)
+  src/factory.ts                       ← createLiveRecordingMachine()
+  src/states/                          ← 상태별 클래스 (State 패턴)
+    NewState.ts
+    RecordingState.ts
+    UpdatingState.ts
+    ErrorState.ts
+    TerminateState.ts
+
+apps/web/src/pages/live-recording/
+  hooks/machine/LiveRecordRuntime.ts               ← 이벤트 큐 + 구독 관리
+  hooks/machine/useLiveRecordingMachine.ts         ← React Hook (useSyncExternalStore)
+  hooks/machine/createLiveRecordCommandExecutor.ts ← API 사이드이펙트 처리
+  contexts/LiveRecordingMachineContext.tsx          ← Context Provider
+```
+
+### 3-2. Command 패턴 — FSM 사이드이펙트 분리
+
+FSM은 순수하게 상태 전이만 담당합니다.
+API 호출 등 사이드이펙트는 `Command`로 표현되어 `CommandExecutor`가 실행합니다.
+
+```
+사용자 클릭
+  → runtime.send({ type: 'EMOTION_CLICK', emotion })
+  → FSM: recording → updating, Command 반환 [START_UPDATE_FROM_CLICK]
+  → CommandExecutor: API 호출
+  → 결과 이벤트 [UPDATE_SUCCESS | UPDATE_FAIL] → runtime.send()
+  → FSM 상태 전이 → React 리렌더
+```
+
+### 3-3. Portal 패턴 — 바텀시트
+
+Stackflow 스크린 레이어 위에 바텀시트를 렌더링하기 위해 `createPortal`을 사용합니다.
+
+```tsx
+// PortalBottomSheet: document.body에 z-index 80으로 마운트
+createPortal(<div className="fixed inset-0 z-[80]">...</div>, document.body)
+```
+
+**사용 방법:**
+```tsx
+<BottomSheetModal.PortalBottomSheet
+  open={isOpen}
+  onOutsideClick={() => setIsOpen(false)}
+  onEntered={() => { /* 애니메이션 완료 후 콜백 */ }}
+  onExited={() => { /* 언마운트 전 정리 */ }}
+>
+  <BottomSheetModal.Root open={isOpen} onOpenChange={setIsOpen}>
+    <BottomSheetModal.Text heading="제목" body="설명" />
+    <BottomSheetModal.Buttons buttons={[...]} />
+  </BottomSheetModal.Root>
+</BottomSheetModal.PortalBottomSheet>
+```
+
+### 3-4. Feature-Sliced Design (FSD) 계층
+
+```
+apps/web/src/
+  app/        ← 앱 초기화, 라우팅 설정 (stackflow.ts)
+  pages/      ← 페이지 단위 (Stackflow Activity)
+  widgets/    ← 페이지 간 공유 복합 컴포넌트 (GlobalNavigationBar 등)
+  features/   ← 기능 단위 (home, auth, record, match, fcm...)
+  entities/   ← 도메인 모델 단위 (auth, match, record...)
+  shared/     ← 공유 유틸, 공통 UI, 상수, 훅
+```
+
+---
+
+## 4. 주요 컴포넌트 구조
+
+### 4-1. 커뮤니티 (`apps/web/src/pages/community/ui/`)
+
+```
+CommunityPage.tsx               ← 진입점, 팀 순위 + 친구 목록
+├── HomeHeaderV2                ← 공유 헤더 (닉네임, 알림, 프로필)
+├── CommunityRankTooltipPopover ← 순위 정보 팝오버
+├── CommunityFriendGrid         ← 친구 카드 그리드 (감정 배지)
+├── CommunityEmptyState         ← 친구 없을 때 빈 상태 + CTA
+├── KBORankBottomSheet          ← KBO 전체 리그 순위 (포탈)
+└── AddFriendBottomSheet        ← 닉네임 검색으로 친구 추가 (포탈 + 키보드 인셋)
+
+FriendDetailPage.tsx            ← 친구 상세 (감정 히스토리)
+├── FriendPhotoBottomSheet      ← 친구 사진 뷰어 (포탈)
+└── ReportBottomSheet           ← 신고 (포탈)
+
+FriendRequestPage.tsx           ← 친구 요청 목록
+└── FriendRequestListItem       ← 요청 항목 (수락/거절)
+```
+
+### 4-2. 홈 V2 (`apps/web/src/pages/home/ui/HomePageV2.tsx`)
+
+```
+HomePageV2
+├── HomeHeaderV2                ← 닉네임, 알림 버튼, 프로필 이동
+├── HomeContentV2
+│   ├── CharacterSection        ← 감정별 캐릭터 SVG + 말풍선 + 배지
+│   ├── TodayMatchCardSkeleton  ← 로딩 스켈레톤
+│   ├── TodayMatchCard          ← 오늘 경기 카드 (감정 기록 버튼 포함)
+│   └── NoMatchCard             ← 경기 없는 날
+└── GlobalNavigationBar
+```
+
+**감정 설정 (`EMOTION_CONFIG`, `apps/web/src/features/home/constants/emotionConfig.ts`):**
+
+| 키 | 캐릭터 | 레이블 |
+|----|--------|--------|
+| `none` | `NoEmotionCharacter` | 감정없음 |
+| `POSITIVE` | `HappyEmotionCharacter` | 기쁨 |
+| `NEGATIVE` | `AngryEmotionCharacter` | 화남 |
+
+### 4-3. 라이브 레코딩 (`apps/web/src/pages/live-recording/`)
+
+```
+LiveRecordPage (ActivityComponentType)
+└── LiveRecordProvider (matchId Context)
+    └── EmotionVoteProvider (감정 퍼센트 상태)
+        └── LiveRecordingMachineProvider (FSM Context)
+            └── LiveRecordPageContent
+                ├── Loading (state === 'new')
+                ├── MyTeamContent (isMyTeam === true)
+                │   ├── GameInfoCard
+                │   ├── EmotionVoteWidget (Lottie 애니메이션)
+                │   └── RecordCameraButton
+                └── OtherTeamLiveRecordPage (isMyTeam === false)
+```
+
+> **Provider 순서가 중요합니다.** `LiveRecordingMachineProvider`는 `EmotionVoteProvider` 안에 있어야
+> Command Executor에서 `setEmotionPercent`를 참조할 수 있습니다.
+
+### 4-4. 바텀시트 컴포넌트 (`apps/web/src/shared/ui/common/BottomSheetModal/`)
+
+| 컴포넌트 | 역할 |
+|----------|------|
+| `PortalBottomSheet` | `createPortal` 래퍼, 슬라이드 애니메이션, 오버레이 |
+| `Root` | 바텀시트 콘텐츠 컨테이너 |
+| `Text` | heading + body 텍스트 영역 |
+| `Image` | 이미지 영역 |
+| `Buttons` | 2-버튼 하단 액션 영역 |
+
+---
+
+## 5. 라우팅
+
+Stackflow `historySyncPlugin`으로 URL과 Activity를 동기화합니다.
+인증이 필요한 Activity는 `withAuth(Component)` HOC로 래핑합니다.
+
+| Activity | URL 패턴 | 컴포넌트 |
+|----------|----------|----------|
+| `Home` | `/` | `HomePageV2` |
+| `MatchSchedule` | `/match-schedule` | `HomePage` (기존) |
+| `Community` | `/community` | `CommunityPage` |
+| `FriendDetail` | `/community/friend-detail` | `FriendDetailPage` |
+| `FriendRequest` | `/community/friend-request` | `FriendRequestPage` |
+| `LiveRecord` | `/live-record/:matchId` | `LiveRecordPage` |
+| `Record` | `/record` | `RecordMainPage` |
+| `RecordDetail` | `/record/:matchRecordId` | `RecordDetailPage` |
+| `My` | `/mypage` | `MyPage` |
+| `Login` | `/login` | `LoginPage` |
+| `OnBoarding` | `/onboarding` | `OnBoardingPage` |
+
+---
+
+## 6. 개발 가이드
+
+### 6-1. 로컬 개발
+
+```bash
+# 패키지 설치 (루트에서)
+pnpm install
+
+# 개발 서버 실행
+pnpm --filter web dev
+
+# 빌드
+pnpm --filter web build
+
+# 린트
+pnpm --filter web lint
+
+# 테스트
+pnpm --filter web test
+
+# 스토리북
+pnpm --filter web storybook
+```
+
+### 6-2. 코드 컨벤션
+
+**파일 네이밍:**
+- 컴포넌트: `PascalCase.tsx`
+- 훅: `useCamelCase.ts`
+- 상수/타입: `camelCase.ts` 또는 `camelCase.type.ts`
+
+**컴포넌트 작성:**
+- `export const ComponentName = () => {}` (named export 권장)
+- 페이지 컴포넌트(Activity)만 `export default`
+- Props 인터페이스는 컴포넌트 파일 상단에 선언
+
+**Tailwind:**
+- v4 사용, CSS 변수 기반 디자인 토큰 (`--color-usage-*`, `--color-brand-*`)
+- 스크롤바 숨김이 필요한 컨테이너에 `scrollbar-hidden` 유틸 적용
+- 라이트/다크 모드는 `light:` variant 사용
+
+**커밋 컨벤션 (gitmoji):**
+- `✨ Feat :` 새 기능
+- `♻️ Refactor :` 리팩터링
+- `💄 Style :` UI/스타일 변경
+- `🐛 Fix :` 버그 수정
+- `📝 Docs :` 문서
+
+### 6-3. 새 바텀시트 추가 방법
+
+1. `pages/<domain>/ui/` 에 `XxxBottomSheet.tsx` 생성
+2. Stackflow 레이어 위에 띄워야 하면 `BottomSheetModal.PortalBottomSheet` 사용
+3. 일반 인라인 바텀시트는 `BottomSheetModal.Root` 단독 사용
+4. 키보드가 올라오는 입력 바텀시트는 `visualViewport` resize 이벤트로 `keyboardInset` 계산
+   → `apps/web/src/pages/community/ui/AddFriendBottomSheet.tsx` 참고
+
+### 6-4. 새 FSM 상태/이벤트 추가 방법
+
+1. `packages/live-recording-machine/src/types.ts` 에 상태/이벤트/커맨드 타입 추가
+2. `packages/live-recording-machine/src/states/` 에 `XxxState.ts` 클래스 생성
+3. 관련 상태의 `handle()` 메서드에 전이 로직 추가
+4. `apps/web/src/pages/live-recording/hooks/machine/createLiveRecordCommandExecutor.ts`
+   에 새 Command 핸들러 추가
+
+### 6-5. 구단 상수 사용
+
+```ts
+import {
+  TEAMS,
+  SHORT_TEAM_NAMES,
+  TEAM_ICONS,
+  type TeamKey,
+} from '@/shared/constants/teams'
+
+TEAMS['LOTTE_GIANTS']            // → '롯데 자이언츠'
+SHORT_TEAM_NAMES['LOTTE_GIANTS'] // → '롯데'
+TEAM_ICONS['LOTTE_GIANTS']       // → LotteIcon (SVG 컴포넌트 | null)
+```
+
+---
+
+## 7. 알려진 이슈 (fix/build 브랜치 기준)
+
+> 아래 이슈들은 이 브랜치가 develop에 머지되기 전에 해결되어야 합니다.
+
+| 우선순위 | 위치 | 이슈 |
+|----------|------|------|
+| 🔴 Critical | `FriendDetailPage.tsx`, `CommunityEmptyState.tsx` | Figma MCP 임시 에셋 URL 13개 사용 — 프로덕션에서 이미지 깨짐 |
+| 🔴 Critical | `CommunityPage.tsx:56`, `FriendDetailPage.tsx:107` | `Math.random()`으로 UI 상태 결정 — 매 마운트마다 랜덤 UI |
+| 🔴 보안 | `apps/web/.env:3` | Kakao REST API Key가 `VITE_` 접두사로 번들에 포함됨 |
+| 🟡 High | `useSocialLogin.ts:80-89` | 비RN 환경에서 가짜 토큰으로 인증 우회 경로 (DEV 환경 게이팅 필요) |
+| 🟡 High | `scheduleRetryCommand.ts` | 재시도 딜레이 없음 — API 실패 시 즉시 3회 연속 호출 |
+| 🟡 High | 커뮤니티 전체 | 하드코딩된 목데이터가 컴포넌트 파일 내에 위치, API 미연동 |
+| 🟡 High | 커뮤니티 전체 | 클릭 핸들러가 `() => {}`로 no-op (알림, 친구 요청, 신고 등) |
+| 🟠 Medium | `auth.api.ts:16,62` | URL 경로/쿼리에 사용자 입력 미인코딩 (`encodeURIComponent` 필요) |
+| 🟠 Medium | `AddFriendBottomSheet` | 닉네임 입력 유효성 검사 없음 |
+| 🟠 Medium | `LiveRecordRuntime.ts:128` | 커맨드 실행 실패 시 FSM에 에러 이벤트 미전달 |
+
+---
+
+## 8. 주의 사항
+
+- **MSW 모킹:** `apps/web/src/mocks/` 에 핸들러가 있습니다. 개발 중 API가 없을 때 자동으로 목 데이터를 반환합니다. **프로덕션 빌드에서 MSW 서비스워커가 포함되지 않도록 반드시 확인하세요.**
+- **브릿지(Bridge):** `@ballog/bridge` 패키지로 React Native 환경 감지 및 네이티브 기능을 호출합니다. `useBridge()` 훅에서 `isRNEnvironment`를 확인하세요.
+- **Stackflow z-index:** AppScreen 내부 레이어와 Portal z-index 충돌에 주의합니다. `PortalBottomSheet`는 `z-[80]`을 사용합니다.
+- **FSM 패키지 빌드:** `@ballog/live-recording-machine`은 `"main": "index.ts"` (소스 직접 참조)이므로 별도 빌드 단계가 없습니다.
+- **온보딩 처리:** `localStorage.getItem('onBoarding')` 값이 없으면 첫 진입 시 `/onboarding`으로 리다이렉트됩니다.
+- **`@ballog/asset` 아이콘:** 모든 SVG 아이콘은 이 패키지에서 import합니다. 직접 `src/assets/`에 SVG를 추가하는 것은 공유 불가 아이콘에만 허용합니다.
+- **API URL:** `.env`의 `VITE_PUBLIC_API_URL`이 현재 `http://`로 설정되어 있습니다. 프로덕션 배포 전 `https://`로 변경하세요.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,32 @@
+# docs/specs/
+
+`/feat-new` 커맨드가 참조하는 API 명세 파일 디렉토리.
+
+## 사용법
+
+1. `docs/specs/<feature-name>.md` 생성
+2. 첫 ` ```yaml ` 코드 블록에 스펙 작성 (→ `_example.md` 참고)
+3. Claude Code에서 `/feat-new <feature-name>` 실행
+
+## 플래그
+
+| 플래그 | 설명 |
+|---|---|
+| `--figma <url>` | Figma 디자인 URL — UI 초안 자동 생성 |
+| `--layer widgets\|features\|pages` | UI 배치 레이어 (기본 `widgets`) |
+| `--dry-run` | 생성 예정 파일만 출력 |
+| `--overwrite` | 기존 슬라이스 덮어쓰기 |
+
+## 스키마
+
+전체 스키마와 네이밍 변환 규칙은 `ballog-spec-format` 스킬 참조.
+
+## 생성 결과
+
+하나의 spec 실행 시 자동으로 만들어지는 파일:
+
+- `apps/web/src/entities/<domain>/` — types / api / queries / hooks / index
+- `apps/web/src/mocks/handlers/<camel>Handlers.ts`
+- `apps/web/src/mocks/data/<camel>.ts`
+- `apps/web/src/mocks/handlers.ts` (import + spread 삽입)
+- `apps/web/src/<layer>/<domain>/ui/<Pascal>.tsx` — `--figma` 있을 때 초안, 없으면 빈 컨테이너

--- a/docs/specs/_example.md
+++ b/docs/specs/_example.md
@@ -1,0 +1,62 @@
+# Feature: Emotion V2 (예시)
+
+매치별 감정 기록 기능의 예시 스펙. 실제 사용할 때 복사해서 수정.
+
+```yaml
+domain: emotion-v2
+layer: widgets
+# figma: https://figma.com/design/xxx/yyy?node-id=1-2
+
+endpoints:
+  - name: getEmotionRecord
+    method: GET
+    path: /emotion/:matchRecordId
+    params:
+      matchRecordId: number
+    response: EmotionResponseDTO
+
+  - name: createEmotion
+    method: POST
+    path: /emotion
+    request: CreateEmotionRequestDTO
+    response: EmotionResponseDTO
+    invalidates: [getEmotionRecord]
+
+  - name: deleteEmotion
+    method: DELETE
+    path: /emotion/:id
+    params:
+      id: number
+    response: "ApiResponse<null>"
+    invalidates: [getEmotionRecord]
+
+types:
+  Emotion:
+    id: number
+    type: "'HAPPY' | 'SAD' | 'ANGRY' | 'NEUTRAL'"
+    matchRecordId: number
+    createdAt: string
+  EmotionResponseDTO: "ApiResponseWithNoSuccess<Emotion[]>"
+  CreateEmotionRequestDTO:
+    type: "Emotion['type']"
+    matchRecordId: number
+
+msw:
+  scenarios:
+    - endpoint: createEmotion
+      when: "body.matchRecordId === 0"
+      status: 400
+      response: { error: "invalid match" }
+    - endpoint: deleteEmotion
+      when: "params.id === '0'"
+      status: 404
+      response: { error: "not found" }
+```
+
+## 메모 공간 (자유 기술)
+
+이 아래는 파싱에서 무시되니 자유롭게 메모.
+
+- 관련 Figma 페이지: (URL)
+- 백엔드 담당자: (이름)
+- 특이사항:


### PR DESCRIPTION
## Summary

- 🔧 추가: Claude Code 커스텀 커맨드 4종 (`/feat-new`, `/commit-pr`, `/review-pr`, `/review-local`)
- 🔧 추가: Ballog 전용 스킬 6종 (FSD/MSW/entity/spec/PR-style/tailwind-cn)
- 🔧 추가: `pre-commit-review` 훅 — `/review-pr` 통과 마커 없이는 커밋 차단
- 📝 추가: `AGENT.md` — 기술 스택·FSD 구조·도메인 컨벤션 정리
- 📝 추가: `docs/specs/` — `/feat-new` 가 읽는 API 명세 템플릿
- 🔧 추가: `.gitignore` — `.omc/`, `WORKFLOW.md`, `.claude/settings.local.json`

Claude Code 기반 개발 워크플로우를 표준화해 FSD/MSW/엔티티 스캐폴딩, 커밋·PR 컨벤션, 리뷰 흐름을 팀 공통으로 사용할 수 있게 했습니다. 신규 개발자/에이전트 모두 동일한 패턴으로 작업하도록 돕는 것이 목표입니다.

---

## 📦 커맨드 사용법

### 1. `/feat-new <feature-name> [옵션]`

**용도**: API 명세 MD를 읽어 entity 슬라이스 + MSW mock + (선택) Figma 기반 UI 초안까지 자동 스캐폴딩.

**사전 준비**: `docs/specs/<feature-name>.md` 작성 (YAML 블록 — `domain` / `endpoints` / `types` 필수). 양식은 `docs/specs/_example.md` 참조.

**옵션**:
- `--figma <url>` — Figma URL. 디자인 컨텍스트로 UI 초안 생성
- `--layer widgets|features|pages` — UI 배치 레이어 (기본 `widgets`)
- `--dry-run` — 생성 예정 파일 트리만 출력
- `--overwrite` — 기존 슬라이스 덮어쓰기 (없으면 질문)

**생성물**:
- `apps/web/src/entities/<kebab>/` — `model/*.type.ts`, `api/*.api.ts`, `api/*.queries.ts`, `hooks/use*Query|Mutation.ts`, barrel `index.ts`
- `apps/web/src/mocks/handlers/<camel>Handlers.ts` + `data/<camel>.ts` + `handlers.ts` 자동 등록
- (옵션) `widgets/features/pages/<kebab>/ui/<Pascal>.tsx` — query 훅 연결된 loading/error/empty 3상태 보일러플레이트

**예시**:
```
/feat-new emotion-v2
/feat-new community-feed --figma https://figma.com/design/... --layer pages
/feat-new match --dry-run
```

---

### 2. `/commit-pr [옵션]`

**용도**: 현재 브랜치의 uncommitted 변경 + unpushed 커밋을 분석해 논리 단위 atomic commit으로 분할 → push → PR 생성.

**옵션**:
- `--base <branch>` — PR base (기본 `develop`)
- `--dry-run` — 커밋 계획만 출력
- `--no-pr` — 커밋·푸시까지만
- `--draft` — PR을 draft로 생성

**커밋 분할 기준**: FSD slice 단위, MSW-entity 짝, prefix별 분류 (✨Feat / 💄Style / ✏️Fix / ♻️Refactor / 📝Docs / 🔧Chore). 한 PR 내 prefix 스타일 통일.

**안전장치**: `git push --force`/`--no-verify`/`git add -A` 금지. `.env`/`*.pem`/`credentials*` 자동 감지·제외.

**예시**:
```
/commit-pr
/commit-pr --base main --draft
/commit-pr --dry-run
```

---

### 3. `/review-pr [base-branch] [--skip-lint]`

**용도**: 현재 브랜치 vs base 전체 diff 리뷰 후 PR 본문까지 생성.

**리뷰 기준** (객체지향 관점):
- **SRP** — 한 파일에 뷰+fetch+상태가공 혼재, `useEffect` 멀티 책임, 파일 300줄↑/함수 50줄↑
- **ISP** — Props 7개↑, 분기별 optional prop 남발, `any`/`Partial<>` 남용
- **View↔로직 분리** — JSX 내부 비즈니스 로직 → `use*` 훅 추출, API/localStorage/날짜 → `shared/lib`
- **Tailwind + cn** — 긴 className → `cn(...)` + bool 인자, 외부 `className` prop은 마지막 인자
- **FSD 경계** — `app→pages→widgets→features→entities→shared` 역행 금지, 같은 레이어 수평 참조 금지, `index.ts` 우회 deep import 금지

**출력**: 🔴 must-fix / 🟡 should-fix / 🟢 nit 버킷 + `path:line` 단위 지적 + PR 본문.

**예시**:
```
/review-pr
/review-pr main --skip-lint
```

---

### 4. `/review-local`

**용도**: 커밋 전 `git diff --cached` 만 빠르게 리뷰 (PR 본문 없음).

**기준**: `/review-pr` 과 동일하되 파일당 핵심 이슈만 압축. lint 영역(포맷/스페이스)은 생략.

**출력**: 마지막 줄에 ✅ `커밋 OK` 또는 🔴 `커밋 보류 권장 (n건)`.

---

## 🛡️ Pre-commit Hook

`.claude/hooks/pre-commit-review.sh` 가 `git commit` 호출을 가로채 `.git/.claude-review-ok` 마커(staged diff의 SHA-256)를 확인합니다. 없으면 차단 → `/review-pr` 또는 `/review-local` 통과 후:

```bash
git diff --cached | shasum -a 256 | awk '{print $1}' > .git/.claude-review-ok
```

마커는 해당 staged 상태에서 1회만 유효합니다.

---

## 🧠 스킬

자동 참조되는 도메인 지식 (`Skill` 호출 시 로드):

| 스킬 | 역할 |
|---|---|
| `ballog-fsd-conventions` | FSD 레이어 의존 방향, public API, import 순서, 네이밍 |
| `ballog-tailwind-cn` | Tailwind + `cn()` 가독성 규칙, twMerge 충돌 회피 |
| `ballog-pr-style` | 이모지/간결 prefix 혼용 규칙, 한국어 PR 본문 틀 |
| `ballog-spec-format` | `/feat-new` 가 읽는 API 명세 YAML 스키마 |
| `ballog-entity-template` | entity 슬라이스 (ky API + query-key-factory + 훅) 템플릿 |
| `ballog-msw-template` | MSW handler/data 생성 + `handlers.ts` 레지스트리 삽입 규칙 |

---

## How did you test this change?

- [x] `/commit-pr` 로 본 PR 생성 — 훅/마커/커밋 흐름 정상 동작
- [x] `.gitignore` 적용 확인 (`WORKFLOW.md`, `.claude/settings.local.json` 제외됨)
- [x] `pre-commit-review.sh` — 마커 없을 때 차단, 마커 일치 시 1회 통과
- [ ] `pnpm lint` / `pnpm --filter web build` — 코드 변경 없음 (문서·툴링만)