### PR TITLE
♻️ Refactor : 캘린더 캐러셀 개선

### DIFF
--- a/apps/web/src/features/calendar/hooks/useDragState.ts
+++ b/apps/web/src/features/calendar/hooks/useDragState.ts
@@ -1,0 +1,124 @@
+import { useCallback, useRef, useState } from 'react'
+import type { PointerEvent, RefObject, TransitionEvent } from 'react'
+
+import { DragSession, type DragDirection } from '../lib/dragSession'
+
+const SNAP_DISTANCE_RATIO = 0.3
+const SNAP_VELOCITY_PX_PER_MS = 0.5
+const TRANSITION_MS = 300
+
+export type SlideDirection = DragDirection
+
+export interface UseDragStateOptions {
+  containerRef: RefObject<HTMLDivElement | null>
+  canCommit: (direction: SlideDirection) => boolean
+  onCommit: (direction: SlideDirection) => void
+}
+
+export const useDragState = ({
+  containerRef,
+  canCommit,
+  onCommit,
+}: UseDragStateOptions) => {
+  const sessionRef = useRef<DragSession | null>(null)
+
+  const [dragX, setDragX] = useState(0)
+  const [transitionEnabled, setTransitionEnabled] = useState(false)
+  const [isDragging, setIsDragging] = useState(false)
+
+  const onPointerDown = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      if (transitionEnabled) return
+      if (e.pointerType === 'mouse' && e.button !== 0) return
+
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId)
+      } catch {
+        // pointer capture may fail on some browsers; safe to ignore
+      }
+
+      sessionRef.current = new DragSession(e.clientX, e.timeStamp, e.pointerId)
+      setTransitionEnabled(false)
+    },
+    [transitionEnabled],
+  )
+
+  const onPointerMove = useCallback((e: PointerEvent<HTMLDivElement>) => {
+    const session = sessionRef.current
+    if (!session) return
+
+    if (session.update(e.clientX, e.timeStamp)) {
+      setIsDragging(true)
+    }
+    setDragX(session.dx)
+  }, [])
+
+  const onPointerEnd = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      const session = sessionRef.current
+      if (!session) return
+      sessionRef.current = null
+
+      try {
+        e.currentTarget.releasePointerCapture(session.pointerId)
+      } catch {
+        // ignore
+      }
+
+      const containerWidth = containerRef.current?.offsetWidth ?? 0
+      const passedDistance =
+        containerWidth > 0 &&
+        Math.abs(session.dx) >= containerWidth * SNAP_DISTANCE_RATIO
+      const passedVelocity =
+        Math.abs(session.velocity) >= SNAP_VELOCITY_PX_PER_MS
+
+      setIsDragging(false)
+      setTransitionEnabled(true)
+
+      const shouldCommit =
+        (passedDistance || passedVelocity) &&
+        !session.isClick() &&
+        canCommit(session.direction)
+
+      if (shouldCommit) {
+        setDragX(session.direction === -1 ? containerWidth : -containerWidth)
+      } else {
+        setDragX(0)
+      }
+    },
+    [canCommit, containerRef],
+  )
+
+  const onTransitionEnd = useCallback(
+    (e: TransitionEvent<HTMLDivElement>) => {
+      if (e.propertyName !== 'transform') return
+      if (!transitionEnabled) return
+
+      const containerWidth = containerRef.current?.offsetWidth ?? 0
+
+      if (containerWidth > 0 && Math.abs(dragX) >= containerWidth) {
+        const direction: SlideDirection = dragX > 0 ? -1 : 1
+        setTransitionEnabled(false)
+        setDragX(0)
+        onCommit(direction)
+      } else {
+        setTransitionEnabled(false)
+      }
+    },
+    [transitionEnabled, dragX, containerRef, onCommit],
+  )
+
+  return {
+    dragX,
+    isDragging,
+    transitionEnabled,
+    transitionMs: TRANSITION_MS,
+    pointerHandlers: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp: onPointerEnd,
+      onPointerCancel: onPointerEnd,
+    },
+    onTransitionEnd,
+  }
+}

--- a/apps/web/src/features/calendar/hooks/useWeek.ts
+++ b/apps/web/src/features/calendar/hooks/useWeek.ts
@@ -1,0 +1,58 @@
+import { useCallback, useMemo, useRef } from 'react'
+import { addDays, differenceInWeeks, startOfWeek } from 'date-fns'
+
+const SLOT_COUNT = 5
+const CENTER_OFFSET = 2
+
+const weekStart = (d: Date) => startOfWeek(d, { weekStartsOn: 0 })
+
+export interface UseWeekOptions {
+  baseDate: Date
+  onBaseDateChange: (newBaseDate: Date) => void
+  maxWeeksRange?: number
+}
+
+export const useWeek = ({
+  baseDate,
+  onBaseDateChange,
+  maxWeeksRange = 104,
+}: UseWeekOptions) => {
+  const initialBaseRef = useRef(weekStart(baseDate))
+
+  const baseWeek = useMemo(() => weekStart(baseDate), [baseDate])
+
+  const slots = useMemo(
+    () =>
+      Array.from({ length: SLOT_COUNT }, (_, i) =>
+        addDays(baseWeek, (i - CENTER_OFFSET) * 7),
+      ),
+    [baseWeek],
+  )
+
+  const weeksFromInitial = useMemo(
+    () => differenceInWeeks(baseWeek, initialBaseRef.current),
+    [baseWeek],
+  )
+
+  const canGoPrev = weeksFromInitial > -maxWeeksRange
+  const canGoNext = weeksFromInitial < maxWeeksRange
+
+  const goPrev = useCallback(() => {
+    if (!canGoPrev) return
+    onBaseDateChange(addDays(baseWeek, -7))
+  }, [canGoPrev, baseWeek, onBaseDateChange])
+
+  const goNext = useCallback(() => {
+    if (!canGoNext) return
+    onBaseDateChange(addDays(baseWeek, 7))
+  }, [canGoNext, baseWeek, onBaseDateChange])
+
+  return {
+    slots,
+    centerOffset: CENTER_OFFSET,
+    canGoPrev,
+    canGoNext,
+    goPrev,
+    goNext,
+  }
+}

--- a/apps/web/src/features/calendar/hooks/useWeekCarousel.ts
+++ b/apps/web/src/features/calendar/hooks/useWeekCarousel.ts
@@ -1,15 +1,8 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
-import type { PointerEvent, TransitionEvent } from 'react'
-import { addDays, differenceInWeeks, startOfWeek } from 'date-fns'
+import { useCallback, useMemo, useRef } from 'react'
+import type { KeyboardEvent } from 'react'
 
-const SLOT_COUNT = 5
-const CENTER_OFFSET = 2
-const SNAP_DISTANCE_RATIO = 0.3
-const SNAP_VELOCITY_PX_PER_MS = 0.5
-const TRANSITION_MS = 200
-const CLICK_THRESHOLD_PX = 5
-
-const weekStart = (d: Date) => startOfWeek(d, { weekStartsOn: 0 })
+import { useDragState, type SlideDirection } from './useDragState'
+import { useWeek } from './useWeek'
 
 export interface UseWeekCarouselOptions {
   baseDate: Date
@@ -17,170 +10,85 @@ export interface UseWeekCarouselOptions {
   maxWeeksRange?: number
 }
 
+export interface WeekCarouselSlot {
+  date: Date
+  offsetIndex: number
+  isCenter: boolean
+}
+
 export const useWeekCarousel = ({
   baseDate,
   onBaseDateChange,
-  maxWeeksRange = 104,
+  maxWeeksRange,
 }: UseWeekCarouselOptions) => {
-  const initialBaseRef = useRef(weekStart(baseDate))
   const containerRef = useRef<HTMLDivElement | null>(null)
-  const dragStateRef = useRef<{
-    startX: number
-    startT: number
-    lastX: number
-    lastT: number
-    pointerId: number
-    moved: boolean
-  } | null>(null)
 
-  const [dragX, setDragX] = useState(0)
-  const [transitionEnabled, setTransitionEnabled] = useState(false)
-  const [isDragging, setIsDragging] = useState(false)
-
-  const baseWeek = useMemo(() => weekStart(baseDate), [baseDate])
-
-  const slotsData = useMemo(
-    () =>
-      Array.from({ length: SLOT_COUNT }, (_, i) =>
-        addDays(baseWeek, (i - CENTER_OFFSET) * 7),
-      ),
-    [baseWeek],
-  )
-
-  const weeksFromInitial = useMemo(
-    () => differenceInWeeks(baseWeek, initialBaseRef.current),
-    [baseWeek],
-  )
-
-  const canGoPrev = weeksFromInitial > -maxWeeksRange
-  const canGoNext = weeksFromInitial < maxWeeksRange
-
-  const goPrev = useCallback(() => {
-    if (!canGoPrev) return
-    onBaseDateChange(addDays(baseWeek, -7))
-  }, [canGoPrev, baseWeek, onBaseDateChange])
-
-  const goNext = useCallback(() => {
-    if (!canGoNext) return
-    onBaseDateChange(addDays(baseWeek, 7))
-  }, [canGoNext, baseWeek, onBaseDateChange])
-
-  const onPointerDown = useCallback(
-    (e: PointerEvent<HTMLDivElement>) => {
-      if (transitionEnabled) return
-      if (e.pointerType === 'mouse' && e.button !== 0) return
-
-      try {
-        e.currentTarget.setPointerCapture(e.pointerId)
-      } catch {
-        // pointer capture may fail on some browsers; safe to ignore
-      }
-
-      dragStateRef.current = {
-        startX: e.clientX,
-        startT: e.timeStamp,
-        lastX: e.clientX,
-        lastT: e.timeStamp,
-        pointerId: e.pointerId,
-        moved: false,
-      }
-      setTransitionEnabled(false)
-    },
-    [transitionEnabled],
-  )
-
-  const onPointerMove = useCallback((e: PointerEvent<HTMLDivElement>) => {
-    const state = dragStateRef.current
-    if (!state) return
-
-    const dx = e.clientX - state.startX
-    state.lastX = e.clientX
-    state.lastT = e.timeStamp
-
-    if (!state.moved && Math.abs(dx) > CLICK_THRESHOLD_PX) {
-      state.moved = true
-      setIsDragging(true)
-    }
-
-    setDragX(dx)
-  }, [])
-
-  const onPointerEnd = useCallback(
-    (e: PointerEvent<HTMLDivElement>) => {
-      const state = dragStateRef.current
-      if (!state) return
-      dragStateRef.current = null
-
-      try {
-        e.currentTarget.releasePointerCapture(state.pointerId)
-      } catch {
-        // ignore
-      }
-
-      const containerWidth = containerRef.current?.offsetWidth ?? 0
-      const dx = state.lastX - state.startX
-      const dt = Math.max(state.lastT - state.startT, 1)
-      const velocity = dx / dt
-
-      const direction = dx > 0 ? -1 : 1
-      const passedDistance =
-        containerWidth > 0 && Math.abs(dx) >= containerWidth * SNAP_DISTANCE_RATIO
-      const passedVelocity = Math.abs(velocity) >= SNAP_VELOCITY_PX_PER_MS
-      const canMove = direction < 0 ? canGoPrev : canGoNext
-
-      setIsDragging(false)
-      setTransitionEnabled(true)
-
-      const shouldCommit =
-        (passedDistance || passedVelocity) &&
-        Math.abs(dx) > CLICK_THRESHOLD_PX &&
-        canMove
-
-      if (shouldCommit) {
-        setDragX(direction === -1 ? containerWidth : -containerWidth)
-      } else {
-        setDragX(0)
-      }
-    },
-    [canGoPrev, canGoNext],
-  )
-
-  const onTransitionEnd = useCallback(
-    (e: TransitionEvent<HTMLDivElement>) => {
-      if (e.propertyName !== 'transform') return
-      if (!transitionEnabled) return
-
-      const containerWidth = containerRef.current?.offsetWidth ?? 0
-
-      if (containerWidth > 0 && Math.abs(dragX) >= containerWidth) {
-        const direction = dragX > 0 ? -1 : 1
-        const newBase = addDays(baseWeek, direction * 7)
-        setTransitionEnabled(false)
-        setDragX(0)
-        onBaseDateChange(newBase)
-      } else {
-        setTransitionEnabled(false)
-      }
-    },
-    [transitionEnabled, dragX, baseWeek, onBaseDateChange],
-  )
-
-  return {
-    containerRef,
-    slotsData,
-    centerOffset: CENTER_OFFSET,
-    dragX,
-    transitionEnabled,
-    transitionMs: TRANSITION_MS,
-    isDragging,
+  const {
+    slots: rawSlots,
+    centerOffset,
     canGoPrev,
     canGoNext,
     goPrev,
     goNext,
-    onPointerDown,
-    onPointerMove,
-    onPointerUp: onPointerEnd,
-    onPointerCancel: onPointerEnd,
+  } = useWeek({ baseDate, onBaseDateChange, maxWeeksRange })
+
+  const canCommit = useCallback(
+    (direction: SlideDirection) => (direction < 0 ? canGoPrev : canGoNext),
+    [canGoPrev, canGoNext],
+  )
+
+  const onCommit = useCallback(
+    (direction: SlideDirection) => {
+      if (direction < 0) goPrev()
+      else goNext()
+    },
+    [goPrev, goNext],
+  )
+
+  const {
+    dragX,
+    isDragging,
+    transitionEnabled,
+    transitionMs,
+    pointerHandlers,
     onTransitionEnd,
+  } = useDragState({ containerRef, canCommit, onCommit })
+
+  const slots = useMemo<WeekCarouselSlot[]>(
+    () =>
+      rawSlots.map((date, i) => ({
+        date,
+        offsetIndex: i - centerOffset,
+        isCenter: i === centerOffset,
+      })),
+    [rawSlots, centerOffset],
+  )
+
+  const transition = transitionEnabled
+    ? `transform ${transitionMs}ms ease-out`
+    : 'none'
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault()
+        goPrev()
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault()
+        goNext()
+      }
+    },
+    [goPrev, goNext],
+  )
+
+  return {
+    containerRef,
+    slots,
+    dragX,
+    isDragging,
+    transition,
+    pointerHandlers,
+    onTransitionEnd,
+    onKeyDown,
   }
 }

--- a/apps/web/src/features/calendar/hooks/useWeekCarousel.ts
+++ b/apps/web/src/features/calendar/hooks/useWeekCarousel.ts
@@ -1,0 +1,186 @@
+import { useCallback, useMemo, useRef, useState } from 'react'
+import type { PointerEvent, TransitionEvent } from 'react'
+import { addDays, differenceInWeeks, startOfWeek } from 'date-fns'
+
+const SLOT_COUNT = 5
+const CENTER_OFFSET = 2
+const SNAP_DISTANCE_RATIO = 0.3
+const SNAP_VELOCITY_PX_PER_MS = 0.5
+const TRANSITION_MS = 200
+const CLICK_THRESHOLD_PX = 5
+
+const weekStart = (d: Date) => startOfWeek(d, { weekStartsOn: 0 })
+
+export interface UseWeekCarouselOptions {
+  baseDate: Date
+  onBaseDateChange: (newBaseDate: Date) => void
+  maxWeeksRange?: number
+}
+
+export const useWeekCarousel = ({
+  baseDate,
+  onBaseDateChange,
+  maxWeeksRange = 104,
+}: UseWeekCarouselOptions) => {
+  const initialBaseRef = useRef(weekStart(baseDate))
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const dragStateRef = useRef<{
+    startX: number
+    startT: number
+    lastX: number
+    lastT: number
+    pointerId: number
+    moved: boolean
+  } | null>(null)
+
+  const [dragX, setDragX] = useState(0)
+  const [transitionEnabled, setTransitionEnabled] = useState(false)
+  const [isDragging, setIsDragging] = useState(false)
+
+  const baseWeek = useMemo(() => weekStart(baseDate), [baseDate])
+
+  const slotsData = useMemo(
+    () =>
+      Array.from({ length: SLOT_COUNT }, (_, i) =>
+        addDays(baseWeek, (i - CENTER_OFFSET) * 7),
+      ),
+    [baseWeek],
+  )
+
+  const weeksFromInitial = useMemo(
+    () => differenceInWeeks(baseWeek, initialBaseRef.current),
+    [baseWeek],
+  )
+
+  const canGoPrev = weeksFromInitial > -maxWeeksRange
+  const canGoNext = weeksFromInitial < maxWeeksRange
+
+  const goPrev = useCallback(() => {
+    if (!canGoPrev) return
+    onBaseDateChange(addDays(baseWeek, -7))
+  }, [canGoPrev, baseWeek, onBaseDateChange])
+
+  const goNext = useCallback(() => {
+    if (!canGoNext) return
+    onBaseDateChange(addDays(baseWeek, 7))
+  }, [canGoNext, baseWeek, onBaseDateChange])
+
+  const onPointerDown = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      if (transitionEnabled) return
+      if (e.pointerType === 'mouse' && e.button !== 0) return
+
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId)
+      } catch {
+        // pointer capture may fail on some browsers; safe to ignore
+      }
+
+      dragStateRef.current = {
+        startX: e.clientX,
+        startT: e.timeStamp,
+        lastX: e.clientX,
+        lastT: e.timeStamp,
+        pointerId: e.pointerId,
+        moved: false,
+      }
+      setTransitionEnabled(false)
+    },
+    [transitionEnabled],
+  )
+
+  const onPointerMove = useCallback((e: PointerEvent<HTMLDivElement>) => {
+    const state = dragStateRef.current
+    if (!state) return
+
+    const dx = e.clientX - state.startX
+    state.lastX = e.clientX
+    state.lastT = e.timeStamp
+
+    if (!state.moved && Math.abs(dx) > CLICK_THRESHOLD_PX) {
+      state.moved = true
+      setIsDragging(true)
+    }
+
+    setDragX(dx)
+  }, [])
+
+  const onPointerEnd = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      const state = dragStateRef.current
+      if (!state) return
+      dragStateRef.current = null
+
+      try {
+        e.currentTarget.releasePointerCapture(state.pointerId)
+      } catch {
+        // ignore
+      }
+
+      const containerWidth = containerRef.current?.offsetWidth ?? 0
+      const dx = state.lastX - state.startX
+      const dt = Math.max(state.lastT - state.startT, 1)
+      const velocity = dx / dt
+
+      const direction = dx > 0 ? -1 : 1
+      const passedDistance =
+        containerWidth > 0 && Math.abs(dx) >= containerWidth * SNAP_DISTANCE_RATIO
+      const passedVelocity = Math.abs(velocity) >= SNAP_VELOCITY_PX_PER_MS
+      const canMove = direction < 0 ? canGoPrev : canGoNext
+
+      setIsDragging(false)
+      setTransitionEnabled(true)
+
+      const shouldCommit =
+        (passedDistance || passedVelocity) &&
+        Math.abs(dx) > CLICK_THRESHOLD_PX &&
+        canMove
+
+      if (shouldCommit) {
+        setDragX(direction === -1 ? containerWidth : -containerWidth)
+      } else {
+        setDragX(0)
+      }
+    },
+    [canGoPrev, canGoNext],
+  )
+
+  const onTransitionEnd = useCallback(
+    (e: TransitionEvent<HTMLDivElement>) => {
+      if (e.propertyName !== 'transform') return
+      if (!transitionEnabled) return
+
+      const containerWidth = containerRef.current?.offsetWidth ?? 0
+
+      if (containerWidth > 0 && Math.abs(dragX) >= containerWidth) {
+        const direction = dragX > 0 ? -1 : 1
+        const newBase = addDays(baseWeek, direction * 7)
+        setTransitionEnabled(false)
+        setDragX(0)
+        onBaseDateChange(newBase)
+      } else {
+        setTransitionEnabled(false)
+      }
+    },
+    [transitionEnabled, dragX, baseWeek, onBaseDateChange],
+  )
+
+  return {
+    containerRef,
+    slotsData,
+    centerOffset: CENTER_OFFSET,
+    dragX,
+    transitionEnabled,
+    transitionMs: TRANSITION_MS,
+    isDragging,
+    canGoPrev,
+    canGoNext,
+    goPrev,
+    goNext,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp: onPointerEnd,
+    onPointerCancel: onPointerEnd,
+    onTransitionEnd,
+  }
+}

--- a/apps/web/src/features/calendar/lib/dragSession.ts
+++ b/apps/web/src/features/calendar/lib/dragSession.ts
@@ -1,0 +1,45 @@
+const CLICK_THRESHOLD_PX = 5
+
+export type DragDirection = -1 | 1
+
+export class DragSession {
+  private lastX: number
+  private lastT: number
+  private moved = false
+
+  public constructor(
+    private readonly startX: number,
+    private readonly startT: number,
+    public readonly pointerId: number,
+  ) {
+    this.lastX = startX
+    this.lastT = startT
+  }
+
+  /** 좌표 갱신 후, '클릭'에서 '드래그'로 막 전이됐다면 true 반환 */
+  public update(x: number, t: number): boolean {
+    this.lastX = x
+    this.lastT = t
+    if (!this.moved && Math.abs(this.dx) > CLICK_THRESHOLD_PX) {
+      this.moved = true
+      return true
+    }
+    return false
+  }
+
+  public get dx() {
+    return this.lastX - this.startX
+  }
+
+  public get velocity() {
+    return this.dx / Math.max(this.lastT - this.startT, 1)
+  }
+
+  public get direction(): DragDirection {
+    return this.dx > 0 ? -1 : 1
+  }
+
+  public isClick() {
+    return Math.abs(this.dx) <= CLICK_THRESHOLD_PX
+  }
+}

--- a/apps/web/src/features/calendar/ui/CalendarHeader.tsx
+++ b/apps/web/src/features/calendar/ui/CalendarHeader.tsx
@@ -18,7 +18,7 @@ import { cn } from '@/shared/lib/classnames'
 
 import { useDate } from '../context/DateContext'
 
-import { CalendarWeekCarousel } from './CalendarWeekCarousel'
+import { CalendarWeekCarouselV2 } from './CalendarWeekCarouselV2'
 
 interface CalendarHeaderProps {
   allMatches: MatchDateMap
@@ -111,7 +111,7 @@ export const CalendarHeader = ({ allMatches }: CalendarHeaderProps) => {
       </div>
 
       {/* week 캐러셀 */}
-      <CalendarWeekCarousel
+      <CalendarWeekCarouselV2
         allMatches={allMatches}
         baseDate={baseDate}
         onChange={setBaseDate}

--- a/apps/web/src/features/calendar/ui/CalendarWeekCarouselV2.tsx
+++ b/apps/web/src/features/calendar/ui/CalendarWeekCarouselV2.tsx
@@ -1,0 +1,104 @@
+import type { KeyboardEvent } from 'react'
+
+import { cn } from '@/shared/lib/classnames'
+import type { MatchDateMap } from '@/entities/match/model/match.type'
+
+import { useWeekCarousel } from '../hooks/useWeekCarousel'
+
+import { CalendarWeekContent } from './CalendarWeekContent'
+
+interface CalendarWeekCarouselV2Props {
+  allMatches: MatchDateMap
+  baseDate: Date
+  onChange: (date: Date) => void
+  selectedDate: Date | null
+  onSelect: (d: Date) => void
+}
+
+export const CalendarWeekCarouselV2 = ({
+  allMatches,
+  baseDate,
+  onChange,
+  selectedDate,
+  onSelect,
+}: CalendarWeekCarouselV2Props) => {
+  const {
+    containerRef,
+    slotsData,
+    centerOffset,
+    dragX,
+    transitionEnabled,
+    transitionMs,
+    isDragging,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+    onTransitionEnd,
+    goPrev,
+    goNext,
+  } = useWeekCarousel({
+    baseDate,
+    onBaseDateChange: onChange,
+  })
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      goPrev()
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      goNext()
+    }
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      role="region"
+      aria-roledescription="carousel"
+      tabIndex={0}
+      className="relative w-full overflow-hidden select-none outline-none"
+      style={{ touchAction: 'pan-y' }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
+      onKeyDown={handleKeyDown}
+    >
+      {slotsData.map((weekDate, i) => {
+        const offsetPercent = (i - centerOffset) * 100
+        const isCenter = i === centerOffset
+
+        return (
+          <div
+            key={i}
+            className={cn(
+              'left-0 top-0 w-full',
+              isCenter ? 'relative' : 'absolute',
+            )}
+            style={{
+              transform: `translate3d(calc(${offsetPercent}% + ${dragX}px), 0, 0)`,
+              transition: transitionEnabled
+                ? `transform ${transitionMs}ms ease-out`
+                : 'none',
+              willChange: 'transform',
+            }}
+            onTransitionEnd={isCenter ? onTransitionEnd : undefined}
+          >
+            <CalendarWeekContent
+              allMatches={allMatches}
+              date={weekDate}
+              selectedDate={selectedDate}
+              onSelect={(d) => {
+                if (isDragging) return
+                onSelect(d)
+                onChange(d)
+              }}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/features/calendar/ui/CalendarWeekCarouselV2.tsx
+++ b/apps/web/src/features/calendar/ui/CalendarWeekCarouselV2.tsx
@@ -1,5 +1,3 @@
-import type { KeyboardEvent } from 'react'
-
 import { cn } from '@/shared/lib/classnames'
 import type { MatchDateMap } from '@/entities/match/model/match.type'
 
@@ -24,33 +22,14 @@ export const CalendarWeekCarouselV2 = ({
 }: CalendarWeekCarouselV2Props) => {
   const {
     containerRef,
-    slotsData,
-    centerOffset,
+    slots,
     dragX,
-    transitionEnabled,
-    transitionMs,
     isDragging,
-    onPointerDown,
-    onPointerMove,
-    onPointerUp,
-    onPointerCancel,
+    transition,
+    pointerHandlers,
     onTransitionEnd,
-    goPrev,
-    goNext,
-  } = useWeekCarousel({
-    baseDate,
-    onBaseDateChange: onChange,
-  })
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === 'ArrowLeft') {
-      e.preventDefault()
-      goPrev()
-    } else if (e.key === 'ArrowRight') {
-      e.preventDefault()
-      goNext()
-    }
-  }
+    onKeyDown,
+  } = useWeekCarousel({ baseDate, onBaseDateChange: onChange })
 
   return (
     <div
@@ -58,47 +37,37 @@ export const CalendarWeekCarouselV2 = ({
       role="region"
       aria-roledescription="carousel"
       tabIndex={0}
-      className="relative w-full overflow-hidden select-none outline-none"
+      className="relative w-full overflow-hidden outline-none select-none"
       style={{ touchAction: 'pan-y' }}
-      onPointerDown={onPointerDown}
-      onPointerMove={onPointerMove}
-      onPointerUp={onPointerUp}
-      onPointerCancel={onPointerCancel}
-      onKeyDown={handleKeyDown}
+      {...pointerHandlers}
+      onKeyDown={onKeyDown}
     >
-      {slotsData.map((weekDate, i) => {
-        const offsetPercent = (i - centerOffset) * 100
-        const isCenter = i === centerOffset
-
-        return (
-          <div
-            key={i}
-            className={cn(
-              'left-0 top-0 w-full',
-              isCenter ? 'relative' : 'absolute',
-            )}
-            style={{
-              transform: `translate3d(calc(${offsetPercent}% + ${dragX}px), 0, 0)`,
-              transition: transitionEnabled
-                ? `transform ${transitionMs}ms ease-out`
-                : 'none',
-              willChange: 'transform',
+      {slots.map((slot, i) => (
+        <div
+          key={i}
+          className={cn(
+            'left-0 top-0 w-full',
+            slot.isCenter ? 'relative' : 'absolute',
+          )}
+          style={{
+            transform: `translate3d(calc(${slot.offsetIndex * 100}% + ${dragX}px), 0, 0)`,
+            transition,
+            willChange: 'transform',
+          }}
+          onTransitionEnd={slot.isCenter ? onTransitionEnd : undefined}
+        >
+          <CalendarWeekContent
+            allMatches={allMatches}
+            date={slot.date}
+            selectedDate={selectedDate}
+            onSelect={(d) => {
+              if (isDragging) return
+              onSelect(d)
+              onChange(d)
             }}
-            onTransitionEnd={isCenter ? onTransitionEnd : undefined}
-          >
-            <CalendarWeekContent
-              allMatches={allMatches}
-              date={weekDate}
-              selectedDate={selectedDate}
-              onSelect={(d) => {
-                if (isDragging) return
-                onSelect(d)
-                onChange(d)
-              }}
-            />
-          </div>
-        )
-      })}
+          />
+        </div>
+      ))}
     </div>
   )
 }

--- a/apps/web/src/pages/friend/ui/FriendDetailPage.tsx
+++ b/apps/web/src/pages/friend/ui/FriendDetailPage.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react'
 import { AppScreen } from '@stackflow/plugin-basic-ui'
-import { AngryEmotionCharacter, KebobMenu } from '@ballog/asset/icons'
+import { AngryEmotionCharacter, KebobMenu, EmptyState } from '@ballog/asset/icons'
 import { toast } from 'sonner'
-import { EmptyState } from '@ballog/asset/icons'
 
 import { BackArrow } from '@/assets/BackArrow'
 

--- a/apps/web/src/pages/friend/ui/FriendDetailPage.tsx
+++ b/apps/web/src/pages/friend/ui/FriendDetailPage.tsx
@@ -2,26 +2,14 @@ import { useState } from 'react'
 import { AppScreen } from '@stackflow/plugin-basic-ui'
 import { AngryEmotionCharacter, KebobMenu } from '@ballog/asset/icons'
 import { toast } from 'sonner'
+import { EmptyState } from '@ballog/asset/icons'
 
 import { BackArrow } from '@/assets/BackArrow'
 
 import { FriendPhotoBottomSheet } from './FriendPhotoBottomSheet'
 import { ReportBottomSheet } from './ReportBottomSheet'
 
-const FRIEND_GALLERY_IMAGE =
-  'https://www.figma.com/api/mcp/asset/51183d4e-e8cf-4582-a42f-6981d41a49ba'
-const EMPTY_SHADOW_IMAGE =
-  'https://www.figma.com/api/mcp/asset/06502ef9-c6b5-41b6-81c2-edffd17bf4fc'
-const EMPTY_BALL_IMAGE =
-  'https://www.figma.com/api/mcp/asset/cd0141bf-6ba8-4305-8f1b-27adf0c076a3'
-const EMPTY_BALL_MASK_IMAGE =
-  'https://www.figma.com/api/mcp/asset/14018a82-cfd0-4c2c-a0c7-ec23e0a6c8be'
-const EMPTY_BALL_TEXTURE_IMAGE =
-  'https://www.figma.com/api/mcp/asset/5524e6ea-5e04-4ef9-ba86-e3b14154bbef'
-const EMPTY_BUBBLE_IMAGE =
-  'https://www.figma.com/api/mcp/asset/6f5644ba-f7c4-44ba-a90f-faaefe56d8cc'
-const EMPTY_EXCLAMATION_IMAGE =
-  'https://www.figma.com/api/mcp/asset/288fd3ad-0174-4d4e-82e3-6954f40ccf52'
+const FRIEND_GALLERY_IMAGE = '/mockImg.png'
 
 const FRIEND_GALLERY_PHOTOS = Array.from({ length: 9 }, (_, index) => ({
   id: `friend-gallery-photo-${index + 1}`,
@@ -40,57 +28,7 @@ const FriendDetailEmptyState = () => {
             오늘 경기부터 감정을 남겨보세요.
           </p>
         </div>
-
-        <div className="flex items-center justify-center w-full py-2">
-          <div className="relative h-[114px] w-[83px]">
-            <img
-              alt=""
-              aria-hidden="true"
-              src={EMPTY_SHADOW_IMAGE}
-              className="absolute bottom-0 left-0 h-7 w-[83px]"
-            />
-            <div className="absolute left-[17px] top-[52px] h-[54px] w-[49px]">
-              <img
-                alt=""
-                aria-hidden="true"
-                src={EMPTY_BALL_IMAGE}
-                className="absolute top-0 left-0 size-12"
-              />
-              <div
-                className="absolute -left-[0.5px] -top-1 h-[53.401px] w-[48.971px]"
-                style={{
-                  WebkitMaskImage: `url('${EMPTY_BALL_MASK_IMAGE}')`,
-                  WebkitMaskPosition: '0.491px 4.017px',
-                  WebkitMaskRepeat: 'no-repeat',
-                  WebkitMaskSize: '47.995px 47.995px',
-                  maskImage: `url('${EMPTY_BALL_MASK_IMAGE}')`,
-                  maskPosition: '0.491px 4.017px',
-                  maskRepeat: 'no-repeat',
-                  maskSize: '47.995px 47.995px',
-                }}
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  src={EMPTY_BALL_TEXTURE_IMAGE}
-                  className="size-full"
-                />
-              </div>
-            </div>
-            <img
-              alt=""
-              aria-hidden="true"
-              src={EMPTY_BUBBLE_IMAGE}
-              className="absolute left-[24.64px] top-0 h-[40.913px] w-[37.215px]"
-            />
-            <img
-              alt=""
-              aria-hidden="true"
-              src={EMPTY_EXCLAMATION_IMAGE}
-              className="absolute left-[40.61px] top-[6.8px] h-[21.194px] w-[5.227px]"
-            />
-          </div>
-        </div>
+        <EmptyState width={83} height={114} className="my-2" />
       </div>
 
       <button


### PR DESCRIPTION
## Summary
- 캘린더 캐러셀 개선

## Detail
- embla 사용 X -> 직접 구현
- 현재 주 + 앞뒤 2주 => 총 5개의 week 슬롯만 렌더링하도록 변경
새 슬라이드를 추가/삭제하지 않고, 기존 5개 슬롯의 날짜만 갱신해 재사용하는 방식으로 구현
빠른 스와이프 시 콘텐츠 마운트 범위를 벗어나 빈 슬라이드가 보이던 문제 해결 (지금까지 몰랐음;;)

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->