### PR TITLE
🐛 Fix : 안드로이드 페이지 헤더 상단 safe-area 처리

### DIFF
--- a/apps/app/app/_layout.tsx
+++ b/apps/app/app/_layout.tsx
@@ -45,7 +45,7 @@ export default function RootLayout() {
     <>
       <ImageBridgeProvider>
         <Stack screenOptions={{ headerShown: false }} />
-        <StatusBar style="light"  />
+        <StatusBar style="dark" />
       </ImageBridgeProvider>
     </>
   )

--- a/apps/app/app/index.tsx
+++ b/apps/app/app/index.tsx
@@ -72,6 +72,6 @@ export default HomeScreen
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#030303',
+    backgroundColor: '#ffffff',
   },
 })

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
     <title>Vite + React + TS</title>
     <style>

--- a/apps/web/src/widgets/header/ui/Header.tsx
+++ b/apps/web/src/widgets/header/ui/Header.tsx
@@ -16,7 +16,7 @@ export const Header = ({
   logo,
 }: HeaderProps) => {
   return (
-    <header className="h-14 flex items-center border-none px-4 relative bg-transparent">
+    <header className="h-14 flex items-center border-none px-4 relative bg-transparent" style={{ paddingTop: 'env(safe-area-inset-top, 0px)' }}>
       {left && <div className="absolute left-4">{left}</div>}
 
       {logo ? (

--- a/apps/web/src/widgets/header/ui/HomeHeaderV2.tsx
+++ b/apps/web/src/widgets/header/ui/HomeHeaderV2.tsx
@@ -14,7 +14,7 @@ export const HomeHeaderV2 = ({
   const { push } = useFlow()
 
   return (
-    <header className="flex items-center justify-between w-full pl-5 pr-2 bg-transparent h-14 shrink-0">
+    <header className="flex items-center justify-between w-full pl-5 pr-2 bg-transparent h-14 shrink-0" style={{ paddingTop: 'env(safe-area-inset-top, 0px)' }}>
       <button
         type="button"
         className="flex items-center gap-0.5"


### PR DESCRIPTION
## 작업 내용
안드로이드 환경에서 페이지 헤더 상단에 어색한 검은 띠/패딩이 보이던 이슈를 수정합니다. 원인은 네이티브 SafeAreaView 컨테이너 배경(`#030303`)이 light 웹 테마(흰색)와 어긋나, edge-to-edge 모드에서 상태바 영역이 검정으로 노출되었기 때문입니다.

## 변경 사항
- `apps/app/app/index.tsx` — SafeAreaView 컨테이너 배경을 `#ffffff` 로 통일
- `apps/app/app/_layout.tsx` — `<StatusBar style="dark" />` 로 변경하여 light 테마에서 아이콘 가독성 확보
- `apps/web/index.html` — viewport meta 에 `viewport-fit=cover` 추가, web 측 `env(safe-area-inset-*)` 활성화
- `apps/web/src/widgets/header/ui/Header.tsx` — `paddingTop: env(safe-area-inset-top, 0px)` 폴백 추가
- `apps/web/src/widgets/header/ui/HomeHeaderV2.tsx` — 동일 폴백 추가

## 영향
- iOS: WKWebView 의 자체 safe-area 처리는 그대로 유지되어 영향 없음
- Android edge-to-edge: 상태바 영역이 흰색으로 렌더링되어 헤더와 자연스럽게 이어짐
- 향후 native SafeAreaView 가 제거되더라도 web 측 폴백 패딩으로 헤더가 상태바 아래로 안전 정렬

## 테스트
- [ ] Android 실기기에서 홈/커뮤니티/마이페이지 헤더 상단 패딩 확인
- [ ] iOS 실기기에서 회귀 없는지 확인
- [ ] 상태바 아이콘이 light 배경에서 잘 보이는지 확인