### PR TITLE
♻️ Refactor : CommunityPage 두 BottomSheet 상태를 단일 activeSheet 로 통합

### DIFF
--- a/apps/web/src/pages/community/ui/CommunityPage.tsx
+++ b/apps/web/src/pages/community/ui/CommunityPage.tsx
@@ -25,14 +25,15 @@ const HERO_STAT = {
   label: '현재 순위',
 }
 
+type ActiveSheet = 'kbo' | 'addFriend' | null
+
 export const CommunityPage = () => {
   const { user } = useUserQuery()
   const { replace, push } = useFlow()
   const { data: friendsData } = useFriendsQuery()
-  const [isKBORankBottomSheetOpen, setIsKBORankBottomSheetOpen] =
-    useState(false)
-  const [isAddFriendBottomSheetOpen, setIsAddFriendBottomSheetOpen] =
-    useState(false)
+  const [activeSheet, setActiveSheet] = useState<ActiveSheet>(null)
+  const closeSheet = (sheet: Exclude<ActiveSheet, null>) =>
+    setActiveSheet((current) => (current === sheet ? null : current))
 
   const friends = friendsData?.data ?? []
   const hasFriends = friends.length > 0
@@ -79,10 +80,7 @@ export const CommunityPage = () => {
                   <button
                     type="button"
                     className="flex items-center body-sm-medium text-brand-neutral-60"
-                    onClick={() => {
-                      setIsAddFriendBottomSheetOpen(false)
-                      setIsKBORankBottomSheetOpen(true)
-                    }}
+                    onClick={() => setActiveSheet('kbo')}
                   >
                     전체 리그 순위
                     <RightArrow className="size-5 text-brand-neutral-60" />
@@ -112,10 +110,7 @@ export const CommunityPage = () => {
                     <button
                       type="button"
                       className="text-white body-md-bold light:text-brand-neutral-80"
-                      onClick={() => {
-                        setIsKBORankBottomSheetOpen(false)
-                        setIsAddFriendBottomSheetOpen(true)
-                      }}
+                      onClick={() => setActiveSheet('addFriend')}
                     >
                       + 친구추가
                     </button>
@@ -134,12 +129,16 @@ export const CommunityPage = () => {
 
         <GlobalNavigationBar />
         <KBORankBottomSheet
-          open={isKBORankBottomSheetOpen}
-          onOpenChange={setIsKBORankBottomSheetOpen}
+          open={activeSheet === 'kbo'}
+          onOpenChange={(open) => {
+            if (!open) closeSheet('kbo')
+          }}
         />
         <AddFriendBottomSheet
-          open={isAddFriendBottomSheetOpen}
-          onOpenChange={setIsAddFriendBottomSheetOpen}
+          open={activeSheet === 'addFriend'}
+          onOpenChange={(open) => {
+            if (!open) closeSheet('addFriend')
+          }}
         />
       </div>
     </AppScreen>


### PR DESCRIPTION
## Summary

- ♻️ 리팩터: `isKBORankBottomSheetOpen` / `isAddFriendBottomSheetOpen` 두 boolean 상태를 단일 `activeSheet: 'kbo' | 'addFriend' | null` 로 통합
- 각 버튼 onClick 마다 분산되어 있던 `setOther(false); setSelf(true)` 패턴 제거
- BottomSheet 의 `onOpenChange` 는 자기 자신을 닫을 때만 상태 변경 (다른 시트가 활성일 때 우발적 close 방지)

두 BottomSheet 가 사실상 mutually exclusive 한데 별도 boolean 으로 관리되어 있었고, 새로운 시트가 추가될수록 N²로 늘어나는 close 페어가 생길 위험이 있어 정리.

## How did you test this change?

- [x] `pnpm --filter web lint` 통과 (0 errors / 60 pre-existing warnings)
- [ ] 수동 QA: 커뮤니티 탭 → "전체 리그 순위" / "+ 친구추가" 토글 시 한 번에 한 시트만 열림, 다른 시트가 열려있을 때 새로 누르면 자동 교체